### PR TITLE
[TWINFACES-449] fix Filtering by Description Displays Incorrect Results in <CrudDataT…

### DIFF
--- a/src/app/workspace/twin/[twinId]/views/twin-fields.tsx
+++ b/src/app/workspace/twin/[twinId]/views/twin-fields.tsx
@@ -71,7 +71,7 @@ export function TwinFields() {
       return { data: [], pagination: {} };
     }
   }
-
+//todo there may be a problem with the operation of filters and displaying extra rows in the table recommended change getRowId={(row) => row.key!} -> getRowId={(row) => row.id!} as was done in "twin-class-statuses" and "twin-class-fields"
   return (
     <InPlaceEditContextProvider>
       <CrudDataTable

--- a/src/app/workspace/twin/[twinId]/views/twin-fields.tsx
+++ b/src/app/workspace/twin/[twinId]/views/twin-fields.tsx
@@ -71,13 +71,12 @@ export function TwinFields() {
       return { data: [], pagination: {} };
     }
   }
-//todo there may be a problem with the operation of filters and displaying extra rows in the table recommended change getRowId={(row) => row.key!} -> getRowId={(row) => row.id!} as was done in "twin-class-statuses" and "twin-class-fields"
   return (
     <InPlaceEditContextProvider>
       <CrudDataTable
         ref={tableRef}
         columns={columns}
-        getRowId={(row) => row.key!}
+        getRowId={(row) => row.id}
         fetcher={fetchFields}
         disablePagination={true}
       />

--- a/src/widgets/tables/twin-class-fields/twin-class-fields.tsx
+++ b/src/widgets/tables/twin-class-fields/twin-class-fields.tsx
@@ -253,7 +253,7 @@ export function TwinClassFieldsTable({
         colDefs.editPermissionId,
         colDefs.required,
       ]}
-      getRowId={(row) => row.id!}
+      getRowId={(row) => row.id}
       fetcher={fetchFields}
       pageSizes={[10, 20, 50]}
       onRowClick={(row) =>

--- a/src/widgets/tables/twin-class-fields/twin-class-fields.tsx
+++ b/src/widgets/tables/twin-class-fields/twin-class-fields.tsx
@@ -253,7 +253,7 @@ export function TwinClassFieldsTable({
         colDefs.editPermissionId,
         colDefs.required,
       ]}
-      getRowId={(row) => row.key!}
+      getRowId={(row) => row.id!}
       fetcher={fetchFields}
       pageSizes={[10, 20, 50]}
       onRowClick={(row) =>

--- a/src/widgets/tables/twin-class-statuses/twin-class-statuses.tsx
+++ b/src/widgets/tables/twin-class-statuses/twin-class-statuses.tsx
@@ -120,7 +120,7 @@ const colDefs: Record<
     cell: (data) => {
       return (
         <Tooltip>
-          <TooltipTrigger asChild>
+          <TooltipTrigger>
             <ColorTile color={data.getValue<string>()} />
           </TooltipTrigger>
           <TooltipContent>{data.getValue<string>()}</TooltipContent>
@@ -136,7 +136,7 @@ const colDefs: Record<
     cell: (data) => {
       return (
         <Tooltip>
-          <TooltipTrigger asChild>
+          <TooltipTrigger>
             <ColorTile color={data.getValue<string>()} />
           </TooltipTrigger>
           <TooltipContent>{data.getValue<string>()}</TooltipContent>
@@ -241,7 +241,7 @@ export function TwinClassStatusesTable({
         colDefs.backgroundColor,
         colDefs.fontColor,
       ]}
-      getRowId={(row) => row.key!}
+      getRowId={(row) => row.id!}
       fetcher={fetchStatuses}
       onRowClick={(row) =>
         router.push(


### PR DESCRIPTION
incorrect rendering of table rows occurred due to non-uniqueness of the passed value (row.key) as a "key" for the row
changes affected "twin-class-statuses" and "twin-class-fields"
perhaps a similar fix will be needed in "twin-class-fields"

to remove the error that occurs:

"Warning: Function components cannot be given refs. Attempts to access this ref will fail. Did you mean to use React.forwardRef()?
Check the render method of SlotClone. Error Component Stack"

since ColorTile does not support ref, I decided to remove asChild from TooltipTrigger - I did not find any obvious consequences