### PR TITLE
[TWINFACES-172] feat: implement alias type view in the tab

### DIFF
--- a/src/app/workspace/twins/[twinId]/twin-context.tsx
+++ b/src/app/workspace/twins/[twinId]/twin-context.tsx
@@ -47,6 +47,8 @@ export function TwinContextProvider({
           showTwin2StatusMode: "DETAILED",
           showTwinMarker2DataListOptionMode: "DETAILED",
           showTwinByHeadMode: "YELLOW",
+          showTwinAliasMode: "C",
+          showTwinTag2DataListOptionMode: "DETAILED",
         },
       })
       .then((response) => {

--- a/src/app/workspace/twins/[twinId]/views/twin-general.tsx
+++ b/src/app/workspace/twins/[twinId]/views/twin-general.tsx
@@ -119,9 +119,7 @@ export function TwinGeneral() {
 
           <TableRow>
             <TableCell>Alias</TableCell>
-            <TableCell className="text-destructive">
-              Not Implemented Yet
-            </TableCell>
+            <TableCell>{twin.aliases}</TableCell>
           </TableRow>
 
           <TableRow>


### PR DESCRIPTION
Task: https://alcosi.atlassian.net/browse/TWINFACES-172

Added: view alias type in twin tab general

Not implemented this fields, because do not maped in BE
![image](https://github.com/user-attachments/assets/035d9312-cd67-440d-8228-a2f01cc589c7)
