### PR TITLE
[TWINFACES-575] fix ui bug in modal for creating twin market

### DIFF
--- a/src/components/form-fields/text/secret-text-form-item.tsx
+++ b/src/components/form-fields/text/secret-text-form-item.tsx
@@ -41,6 +41,7 @@ export const SecretTextFormItem = ({
           value={fieldValue ?? ""}
           onChange={onChange}
           type={type === "password" ? (showSecret ? "text" : "password") : type}
+          className="pr-15"
           {...props}
         />
         <Button


### PR DESCRIPTION
task: https://alcosi.atlassian.net/browse/TWINFACES-575 Modal for creating twin market UI bug

`the symbols do not block the eye`

<img width="1123" alt="Снимок экрана 2025-06-13 в 14 00 30" src="https://github.com/user-attachments/assets/4cfdb3a2-76c9-4d8f-895f-8a9ec384cf3c" />
