### PR TITLE
[TWINFACES-585] replaced show mode on twin fields tab

### DIFF
--- a/src/entities/twin/api/api-service.ts
+++ b/src/entities/twin/api/api-service.ts
@@ -89,7 +89,7 @@ export function createTwinApi(settings: ApiSettings) {
           showTwin2TwinClassMode: "DETAILED",
           showTwinClass2TwinClassFieldMode: "DETAILED",
           showTwinFieldCollectionMode: "ALL_FIELDS",
-          showTwinClassFieldDescriptor2DataListOptionMode: "DETAILED",
+          showTwinField2DataListOptionMode: "DETAILED",
           showTwinClass2LinkMode: "DETAILED",
           showTwinField2UserMode: "DETAILED",
           showTwinClassMode: "DETAILED",

--- a/src/entities/twin/server/libs/helpers.ts
+++ b/src/entities/twin/server/libs/helpers.ts
@@ -75,7 +75,10 @@ export function hydrateTwinFromMap<T extends Twin_HYDRATED>(
     >((acc, [key, value]) => {
       const twinClassField = KEY_TO_TWIN_CLASS_FIELD_MAP[key];
       const fieldValue =
-        relatedObjects.dataListsOptionMap?.[value] ?? value ?? "";
+        relatedObjects.dataListsOptionMap?.[value] ??
+        relatedObjects.twinMap?.[value] ??
+        value ??
+        "";
 
       acc[key] = {
         ...twinClassField,

--- a/src/entities/twin/server/libs/helpers.ts
+++ b/src/entities/twin/server/libs/helpers.ts
@@ -4,6 +4,7 @@ import { TwinClassField } from "@/entities/twin-class-field";
 import { TwinFlowTransition } from "@/entities/twin-flow-transition";
 import { TwinFieldUI } from "@/entities/twinField";
 import { RelatedObjects } from "@/shared/api";
+import { isPopulatedString } from "@/shared/libs";
 
 import { Twin, Twin_HYDRATED } from "../api";
 
@@ -74,11 +75,33 @@ export function hydrateTwinFromMap<T extends Twin_HYDRATED>(
       Record<string, TwinFieldUI>
     >((acc, [key, value]) => {
       const twinClassField = KEY_TO_TWIN_CLASS_FIELD_MAP[key];
-      const fieldValue =
-        relatedObjects.dataListsOptionMap?.[value] ??
-        relatedObjects.twinMap?.[value] ??
-        value ??
-        "";
+
+      // ??? extract to function
+      // TODO: test if dataListsOptionMap & twinMap work without bugs
+      let fieldValue = "";
+
+      if (twinClassField?.descriptor?.fieldType === "textV1") {
+        fieldValue = value;
+      }
+
+      if (
+        twinClassField?.descriptor?.fieldType === "selectListV1" ||
+        twinClassField?.descriptor?.fieldType === "selectLongV1" ||
+        twinClassField?.descriptor?.fieldType === "selectSharedInHeadV1"
+      ) {
+        fieldValue = isPopulatedString(value)
+          ? relatedObjects.dataListsOptionMap?.[value]
+          : " ";
+      }
+
+      if (
+        twinClassField?.descriptor?.fieldType === "selectLinkV1" ||
+        twinClassField?.descriptor?.fieldType === "selectLinkLongV1"
+      ) {
+        fieldValue = isPopulatedString(value)
+          ? relatedObjects.twinMap?.[value]
+          : " ";
+      }
 
       acc[key] = {
         ...twinClassField,

--- a/src/entities/twinField/libs/helpers.ts
+++ b/src/entities/twinField/libs/helpers.ts
@@ -24,12 +24,18 @@ export const hydrateTwinFieldFromMap = ({
     case TwinFieldType.selectListV1:
     case TwinFieldType.selectLongV1:
     case TwinFieldType.selectSharedInHeadV1:
-    case TwinFieldType.selectUserV1:
-    case TwinFieldType.selectUserLongV1:
-    case TwinFieldType.selectLinkV1:
-    case TwinFieldType.selectLinkLongV1:
       twinFieldKeyValue.value =
         relatedObjects?.dataListsOptionMap?.[value] ?? value;
+      break;
+
+    case TwinFieldType.selectUserV1:
+    case TwinFieldType.selectUserLongV1:
+      twinFieldKeyValue.value = relatedObjects?.userMap?.[value] ?? value;
+      break;
+
+    case TwinFieldType.selectLinkV1:
+    case TwinFieldType.selectLinkLongV1:
+      twinFieldKeyValue.value = relatedObjects?.twinMap?.[value] ?? value;
       break;
   }
 

--- a/src/entities/twinField/libs/types.ts
+++ b/src/entities/twinField/libs/types.ts
@@ -1,5 +1,7 @@
 import { DataListOptionV3 } from "@/entities/datalist-option";
 import { TwinClassField } from "@/entities/twin-class-field";
+import { Twin } from "@/entities/twin/server";
+import { User } from "@/entities/user";
 import { components } from "@/shared/api/generated/schema";
 import { RequireFields, createEnum } from "@/shared/libs";
 
@@ -9,7 +11,7 @@ export type TwinFieldUI = RequireFields<
   TwinClassField,
   "id" | "key" | "name" | "description" | "required" | "descriptor"
 > & {
-  value: string | DataListOptionV3;
+  value: string | DataListOptionV3 | Twin | User;
 };
 
 export type TwinClassFieldDescriptorTextV1 =

--- a/src/entities/twinField/libs/types.ts
+++ b/src/entities/twinField/libs/types.ts
@@ -9,7 +9,7 @@ import { TWIN_FIELD_TYPES } from "./constants";
 
 export type TwinFieldUI = RequireFields<
   TwinClassField,
-  "id" | "key" | "name" | "description" | "required" | "descriptor"
+  "id" | "key" | "descriptor"
 > & {
   value: string | DataListOptionV3 | Twin | User;
 };

--- a/src/features/twin/ui/field-editor/field-editor.tsx
+++ b/src/features/twin/ui/field-editor/field-editor.tsx
@@ -27,8 +27,7 @@ export type TwinFieldEditorProps = {
   twinId: string;
   twin: Twin;
   label?: ReactNode;
-  // field: FieldProps; // TODO: change to TwinFieldUI ???
-  field: TwinFieldUI; // TODO: change to TwinFieldUI ???
+  field: TwinFieldUI;
   schema?: ZodType;
   relatedObjects?: RelatedObjects;
   onSuccess?: () => void;
@@ -95,6 +94,10 @@ export function TwinFieldEditor({
     }
   }
 
+  const fieldValue = isPopulatedString(field.value)
+    ? field.value
+    : field.value.id!;
+
   return (
     <div>
       {label &&
@@ -109,7 +112,7 @@ export function TwinFieldEditor({
       ) : (
         <InPlaceEdit
           id={id}
-          value={field.value}
+          value={fieldValue}
           valueInfo={{
             type: AutoFormValueType.twinField,
             label: undefined,

--- a/src/features/twin/ui/field-editor/field-editor.tsx
+++ b/src/features/twin/ui/field-editor/field-editor.tsx
@@ -14,20 +14,21 @@ import {
   useTwinUpdate,
 } from "@/entities/twin";
 import { Twin, TwinUpdateRq, hydrateTwinFromMap } from "@/entities/twin/server";
+import { TwinFieldUI } from "@/entities/twinField";
 import { RelatedObjects } from "@/shared/api";
 import { cn, isPopulatedString } from "@/shared/libs";
 
 import { InPlaceEdit } from "../../../inPlaceEdit";
 import { SELF_FIELD_MAP } from "./constants";
 import { InheritedFieldPreview } from "./inherited-field-preview";
-import { FieldProps } from "./types";
 
 export type TwinFieldEditorProps = {
   id: string;
   twinId: string;
   twin: Twin;
   label?: ReactNode;
-  field: FieldProps;
+  // field: FieldProps; // TODO: change to TwinFieldUI ???
+  field: TwinFieldUI; // TODO: change to TwinFieldUI ???
   schema?: ZodType;
   relatedObjects?: RelatedObjects;
   onSuccess?: () => void;
@@ -72,7 +73,6 @@ export function TwinFieldEditor({
     return (
       <InheritedFieldPreview
         field={field}
-        relatedObjects={relatedObjects}
         disabled={disabled}
         onChange={handleOnSubmit}
       />

--- a/src/features/twin/ui/field-editor/inherited-field-preview.tsx
+++ b/src/features/twin/ui/field-editor/inherited-field-preview.tsx
@@ -32,7 +32,7 @@ export function InheritedFieldPreview({
   disabled = false,
   onChange,
 }: Props) {
-  const { descriptor, value } = field;
+  const { descriptor, value, name } = field;
   const type = descriptor?.fieldType;
 
   switch (type) {
@@ -67,24 +67,30 @@ export function InheritedFieldPreview({
     case "selectListV1":
     case "selectLongV1":
     case "selectSharedInHeadV1": {
-      const data = relatedObjects?.dataListsOptionMap?.[value];
+      const data = relatedObjects?.dataListsOptionMap?.[value] ?? {
+        id: value,
+        name,
+      };
+
       return (
-        data && (
-          <DatalistOptionResourceLink
-            data={data}
-            withTooltip
-            disabled={disabled}
-          />
-        )
+        <DatalistOptionResourceLink
+          data={data}
+          withTooltip
+          disabled={disabled}
+        />
       );
     }
 
     case "selectLinkV1":
     case "selectLinkLongV1": {
-      const data = relatedObjects?.twinMap?.[value];
-      return (
-        data && <TwinResourceLink data={data} withTooltip disabled={disabled} />
-      );
+      if (!value) return null;
+
+      const data = relatedObjects?.twinMap?.[value] ?? {
+        id: value,
+        name,
+      };
+
+      return <TwinResourceLink data={data} withTooltip disabled={disabled} />;
     }
 
     case "selectUserV1":

--- a/src/features/twin/ui/field-editor/inherited-field-preview.tsx
+++ b/src/features/twin/ui/field-editor/inherited-field-preview.tsx
@@ -35,11 +35,6 @@ export function InheritedFieldPreview({
 }: Props) {
   const { descriptor, value } = field;
   const type = descriptor?.fieldType;
-  const fieldValue = isPopulatedString(value)
-    ? value
-    : isObject(value) && isPopulatedString(value.id)
-      ? value.id
-      : "";
 
   switch (type) {
     case "urlV1": {
@@ -163,5 +158,5 @@ export function InheritedFieldPreview({
     }
   }
 
-  return <p>{fieldValue}</p>;
+  return <p>{`${value}`}</p>;
 }

--- a/src/features/twin/ui/field-editor/types.ts
+++ b/src/features/twin/ui/field-editor/types.ts
@@ -24,10 +24,10 @@ export type TwinSelfFieldMeta = {
   className?: string;
 };
 
-export type FieldProps = {
-  id: string;
-  key: TwinSelfFieldKey | string;
-  value: string;
-  name?: string;
-  descriptor: TwinClassField["descriptor"];
-};
+// export type FieldProps = {
+//   id: string;
+//   key: TwinSelfFieldKey | string;
+//   value: string;
+//   name?: string;
+//   descriptor: TwinClassField["descriptor"];
+// };

--- a/src/features/twin/ui/field-editor/types.ts
+++ b/src/features/twin/ui/field-editor/types.ts
@@ -6,7 +6,6 @@ import {
   FieldDescriptorText,
   TwinSelfFieldKey,
 } from "@/entities/twin";
-import { TwinClassField } from "@/entities/twin-class-field";
 import { Twin_HYDRATED } from "@/entities/twin/server";
 
 type FieldDescriptor =
@@ -23,11 +22,3 @@ export type TwinSelfFieldMeta = {
   ) => ReactNode;
   className?: string;
 };
-
-// export type FieldProps = {
-//   id: string;
-//   key: TwinSelfFieldKey | string;
-//   value: string;
-//   name?: string;
-//   descriptor: TwinClassField["descriptor"];
-// };

--- a/src/screens/twin/views/twin-fields.tsx
+++ b/src/screens/twin/views/twin-fields.tsx
@@ -9,7 +9,7 @@ import { TwinContext } from "@/features/twin";
 import { TwinClassFieldResourceLink } from "@/features/twin-class-field/ui";
 import { TwinFieldEditor } from "@/features/twin/ui";
 import { PagedResponse } from "@/shared/api";
-import { isObject, isTruthy } from "@/shared/libs";
+import { isObject, isPopulatedString } from "@/shared/libs";
 import { CrudDataTable, DataTableHandle } from "@/widgets/crud-data-table";
 import { resolveTwinFieldSchema } from "@/widgets/form-fields";
 
@@ -37,6 +37,16 @@ export function TwinFields() {
       accessorKey: "value",
       header: "Value",
       cell: ({ row: { original } }) => {
+        console.log("foobar original", original.name);
+
+        // const value = isPopulatedString(original.value)
+        //   ? original.value
+        //   : original.value.id!;
+
+        // const name = isObject(original.value)
+        //   ? original.value.name
+        //   : original.name;
+
         return (
           <div
             className="inline-block w-full min-w-[300px]"
@@ -47,18 +57,14 @@ export function TwinFields() {
               id={original.id}
               twinId={twinId}
               twin={original}
-              field={{
-                id: original.id,
-                key: original.key,
-                value:
-                  isObject(original.value) && isTruthy(original.value.id)
-                    ? String(original.value.id)
-                    : String(original.value),
-                name: isObject(original.value)
-                  ? original.value.name
-                  : original.name,
-                descriptor: original.descriptor,
-              }}
+              field={original}
+              // field={{
+              //   id: original.id,
+              //   key: original.key,
+              //   value,
+              //   name,
+              //   descriptor: original.descriptor,
+              // }}
               schema={resolveTwinFieldSchema(original)}
               onSuccess={tableRef.current?.refresh}
               editable

--- a/src/screens/twin/views/twin-fields.tsx
+++ b/src/screens/twin/views/twin-fields.tsx
@@ -54,7 +54,9 @@ export function TwinFields() {
                   isObject(original.value) && isTruthy(original.value.id)
                     ? String(original.value.id)
                     : String(original.value),
-                name: original.name,
+                name: isObject(original.value)
+                  ? original.value.name
+                  : original.name,
                 descriptor: original.descriptor,
               }}
               schema={resolveTwinFieldSchema(original)}

--- a/src/screens/twin/views/twin-fields.tsx
+++ b/src/screens/twin/views/twin-fields.tsx
@@ -9,7 +9,6 @@ import { TwinContext } from "@/features/twin";
 import { TwinClassFieldResourceLink } from "@/features/twin-class-field/ui";
 import { TwinFieldEditor } from "@/features/twin/ui";
 import { PagedResponse } from "@/shared/api";
-import { isObject, isPopulatedString } from "@/shared/libs";
 import { CrudDataTable, DataTableHandle } from "@/widgets/crud-data-table";
 import { resolveTwinFieldSchema } from "@/widgets/form-fields";
 
@@ -37,16 +36,6 @@ export function TwinFields() {
       accessorKey: "value",
       header: "Value",
       cell: ({ row: { original } }) => {
-        console.log("foobar original", original.name);
-
-        // const value = isPopulatedString(original.value)
-        //   ? original.value
-        //   : original.value.id!;
-
-        // const name = isObject(original.value)
-        //   ? original.value.name
-        //   : original.name;
-
         return (
           <div
             className="inline-block w-full min-w-[300px]"
@@ -58,13 +47,6 @@ export function TwinFields() {
               twinId={twinId}
               twin={original}
               field={original}
-              // field={{
-              //   id: original.id,
-              //   key: original.key,
-              //   value,
-              //   name,
-              //   descriptor: original.descriptor,
-              // }}
               schema={resolveTwinFieldSchema(original)}
               onSuccess={tableRef.current?.refresh}
               editable

--- a/src/screens/twin/views/twin-general.tsx
+++ b/src/screens/twin/views/twin-general.tsx
@@ -185,12 +185,14 @@ export function TwinGeneral() {
                 id="twin.name"
                 twinId={twin.id}
                 twin={twin}
-                // TODO: ??? @berdimyradov
                 field={{
                   id: STATIC_TWIN_FIELD_KEY_TO_ID_MAP["name"],
                   key: "name",
                   value: twin.name,
                   descriptor: FieldDescriptorText.PLAIN,
+                  name: twin.name ?? "",
+                  description: twin.description ?? "",
+                  required: false,
                 }}
                 schema={z.string().min(3)}
                 onSuccess={refresh}
@@ -211,6 +213,9 @@ export function TwinGeneral() {
                   key: "description",
                   value: twin.description ?? "",
                   descriptor: FieldDescriptorText.MARKDOWN_GITHUB,
+                  name: twin.description ?? "",
+                  description: twin.description ?? "",
+                  required: false,
                 }}
                 schema={z.string().min(3)}
                 onSuccess={refresh}

--- a/src/screens/twin/views/twin-general.tsx
+++ b/src/screens/twin/views/twin-general.tsx
@@ -190,9 +190,6 @@ export function TwinGeneral() {
                   key: "name",
                   value: twin.name,
                   descriptor: FieldDescriptorText.PLAIN,
-                  name: twin.name ?? "",
-                  description: twin.description ?? "",
-                  required: false,
                 }}
                 schema={z.string().min(3)}
                 onSuccess={refresh}
@@ -213,9 +210,6 @@ export function TwinGeneral() {
                   key: "description",
                   value: twin.description ?? "",
                   descriptor: FieldDescriptorText.MARKDOWN_GITHUB,
-                  name: twin.description ?? "",
-                  description: twin.description ?? "",
-                  required: false,
                 }}
                 schema={z.string().min(3)}
                 onSuccess={refresh}

--- a/src/screens/twin/views/twin-general.tsx
+++ b/src/screens/twin/views/twin-general.tsx
@@ -185,6 +185,7 @@ export function TwinGeneral() {
                 id="twin.name"
                 twinId={twin.id}
                 twin={twin}
+                // TODO: ??? @berdimyradov
                 field={{
                   id: STATIC_TWIN_FIELD_KEY_TO_ID_MAP["name"],
                   key: "name",

--- a/src/widgets/faces/widgets/views/tw004/utils.ts
+++ b/src/widgets/faces/widgets/views/tw004/utils.ts
@@ -64,9 +64,6 @@ export async function buildFieldEditorProps(
             key,
             value,
             descriptor,
-            name: "",
-            required: false,
-            description: "",
           },
         },
       };

--- a/src/widgets/faces/widgets/views/tw004/utils.ts
+++ b/src/widgets/faces/widgets/views/tw004/utils.ts
@@ -1,6 +1,7 @@
 import { getAuthHeaders } from "@/entities/face";
 import { TwinSelfFieldId } from "@/entities/twin";
 import { Twin } from "@/entities/twin/server";
+import { hydrateTwinFieldFromMap } from "@/entities/twinField";
 import { User } from "@/entities/user";
 import { TwinFieldEditorProps } from "@/features/twin/ui";
 import { SELF_FIELD_MAP } from "@/features/twin/ui/field-editor/constants";
@@ -63,6 +64,9 @@ export async function buildFieldEditorProps(
             key,
             value,
             descriptor,
+            name: "",
+            required: false,
+            description: "",
           },
         },
       };
@@ -79,17 +83,17 @@ export async function buildFieldEditorProps(
       );
     }
 
+    const hydratedField = hydrateTwinFieldFromMap({
+      dto: [inheritedKey, value],
+      relatedObjects: data.relatedObjects,
+    });
+
     return {
       ok: true,
       data: {
         twin,
         relatedObjects,
-        field: {
-          id: fieldId,
-          key: inheritedKey,
-          value,
-          descriptor: twinClassField?.descriptor,
-        },
+        field: hydratedField,
       },
     };
   } catch (error) {

--- a/src/widgets/tables/twins/twins.tsx
+++ b/src/widgets/tables/twins/twins.tsx
@@ -438,7 +438,7 @@ function extractTwinFieldColumnsAndFilters({
         {
           id: field.key,
           accessorFn: (row) => row.fields?.[field.key!] ?? null,
-          header: column.label ?? field.name,
+          header: column.label ?? field.key,
           cell: ({ row: { original } }) => {
             const twinField = original.fields?.[field.key!] as TwinFieldUI;
 

--- a/src/widgets/tables/twins/twins.tsx
+++ b/src/widgets/tables/twins/twins.tsx
@@ -39,9 +39,7 @@ import { UserResourceLink } from "@/features/user/ui";
 import {
   formatIntlDate,
   isEmptyString,
-  isObject,
   isPopulatedArray,
-  isTruthy,
   isUndefined,
 } from "@/shared/libs";
 import { GuidWithCopy } from "@/shared/ui";
@@ -452,16 +450,6 @@ function extractTwinFieldColumnsAndFilters({
               <TwinFieldEditor
                 id={twinField.id}
                 field={twinField}
-                // field={{
-                //   id: twinField.id,
-                //   key: twinField.key,
-                //   value:
-                //     isObject(twinField.value) && isTruthy(twinField.value.id)
-                //       ? (twinField.value.id as string)
-                //       : (twinField.value as string),
-                //   name: twinField.name,
-                //   descriptor: twinField.descriptor,
-                // }}
                 twinId={original.id}
                 twin={original}
                 editable={false}

--- a/src/widgets/tables/twins/twins.tsx
+++ b/src/widgets/tables/twins/twins.tsx
@@ -451,16 +451,17 @@ function extractTwinFieldColumnsAndFilters({
             return (
               <TwinFieldEditor
                 id={twinField.id}
-                field={{
-                  id: twinField.id,
-                  key: twinField.key,
-                  value:
-                    isObject(twinField.value) && isTruthy(twinField.value.id)
-                      ? (twinField.value.id as string)
-                      : (twinField.value as string),
-                  name: twinField.name,
-                  descriptor: twinField.descriptor,
-                }}
+                field={twinField}
+                // field={{
+                //   id: twinField.id,
+                //   key: twinField.key,
+                //   value:
+                //     isObject(twinField.value) && isTruthy(twinField.value.id)
+                //       ? (twinField.value.id as string)
+                //       : (twinField.value as string),
+                //   name: twinField.name,
+                //   descriptor: twinField.descriptor,
+                // }}
                 twinId={original.id}
                 twin={original}
                 editable={false}


### PR DESCRIPTION
task: https://alcosi.atlassian.net/browse/TWINFACES-585 replaced show mode on twin fields tab

1. replaced show mode c `showTwinClassFieldDescriptor2DataListOptionMode` with `showTwinField2DataListOptionMode `
2. added logic for displaying on `twin fields` tab, `I think this logic is necessary`

test: `localhost`
- for show test `dataListsOptionMap:` core/twins/0565ba48-ed2f-4ae5-ac38-cf0fb3bbedcb#fields
- for show test `twinMap:` core/twins/42699cfb-04b9-486f-8c70-214473ce7c6d#fields

test: `dev-twins-cabinet.worknroll.pro`
- for show test `dataListsOptionMap:`- core/twins/f75b4c2e-11b6-4fcf-9c53-35874db2ef51#fields
- for show test `twinMap:` core/twins/42699cfb-04b9-486f-8c70-214473ce7c6d#fields

test: `dev-OnShelves`
core/twins/32563d84-a11d-4b47-b054-662cc2c8104e#fields