### PR TITLE
[TWINFACES-617] [face breadcrumbs] BC001

### DIFF
--- a/src/app/browse/[twinId]/layout.tsx
+++ b/src/app/browse/[twinId]/layout.tsx
@@ -1,0 +1,62 @@
+import { notFound } from "next/navigation";
+import { ReactNode } from "react";
+
+import { fetchBC001Face, getAuthHeaders } from "@/entities/face";
+import { Twin_DETAILED, fetchTwinById } from "@/entities/twin/server";
+import { withRedirectOnUnauthorized } from "@/features/auth";
+import { isTruthy, safe } from "@/shared/libs";
+import { PrivateLayoutProviders } from "@/widgets/layout";
+
+type Props = {
+  children: ReactNode;
+  params: { twinId: string };
+};
+
+export default async function Layout({ children, params }: Props) {
+  const { twinId } = await params;
+  const header = await getAuthHeaders();
+  const query = {
+    showTwinMode: "DETAILED",
+    showTwin2TwinClassMode: "DETAILED",
+    showTwinClassPage2FaceMode: "DETAILED",
+    showTwin2FaceMode: "DETAILED",
+  } as const;
+
+  const twinResult = await safe(
+    withRedirectOnUnauthorized(() =>
+      fetchTwinById<Twin_DETAILED>(twinId, { header, query })
+    )
+  );
+
+  if (!twinResult.ok) notFound();
+
+  const { twin, relatedObjects } = twinResult.data;
+
+  const breadCrumbsResult = await safe(
+    withRedirectOnUnauthorized(() =>
+      fetchBC001Face(twin.breadCrumbsFaceId!, twin.id)
+    )
+  );
+
+  if (!breadCrumbsResult.ok) {
+    console.error(`Failed to load bread crumbs data:`, breadCrumbsResult.error);
+    return undefined;
+  }
+
+  const breadCrumbsFace = relatedObjects.faceMap?.[twin.breadCrumbsFaceId!];
+  const breadCrumbsData = isTruthy(breadCrumbsFace)
+    ? breadCrumbsResult.data.breadCrumbs
+    : undefined;
+  const sortedBreadCrumbsData = breadCrumbsData?.items?.sort(
+    (b, a) => (a.order ?? 0) - (b.order ?? 0)
+  );
+
+  return (
+    <PrivateLayoutProviders
+      breadcrumbs={sortedBreadCrumbsData}
+      activeTwinId={twin.id}
+    >
+      {children}
+    </PrivateLayoutProviders>
+  );
+}

--- a/src/app/browse/[twinId]/page.tsx
+++ b/src/app/browse/[twinId]/page.tsx
@@ -1,0 +1,50 @@
+import { notFound } from "next/navigation";
+
+import { getAuthHeaders } from "@/entities/face";
+import { Twin_DETAILED, fetchTwinById } from "@/entities/twin/server";
+import { withRedirectOnUnauthorized } from "@/features/auth";
+import { safe } from "@/shared/libs";
+import { StatusAlert } from "@/widgets/faces/components";
+import { LayoutRenderer } from "@/widgets/faces/layouts";
+
+type Props = {
+  params: Promise<{
+    twinId: string;
+  }>;
+};
+
+export default async function Page(props: Props) {
+  const params = await props.params;
+  const header = await getAuthHeaders();
+  const query = {
+    showTwinMode: "DETAILED",
+    showTwin2TwinClassMode: "DETAILED",
+    showTwinClassPage2FaceMode: "DETAILED",
+    showTwin2FaceMode: "DETAILED",
+  } as const;
+
+  const result = await safe(
+    withRedirectOnUnauthorized(() =>
+      fetchTwinById<Twin_DETAILED>(params.twinId, { header, query })
+    )
+  );
+
+  if (!result.ok) {
+    notFound();
+  }
+
+  const { twin, relatedObjects } = result.data;
+
+  if (twin.pageFaceId) {
+    return <LayoutRenderer pageFaceId={twin.pageFaceId} twinId={twin.id} />;
+  }
+
+  return (
+    <StatusAlert
+      variant="warn"
+      title="Page not set up yet"
+      message="We're working on it. Please check back soon!"
+      className="mt-4"
+    />
+  );
+}

--- a/src/app/browse/[twinId]/page.tsx
+++ b/src/app/browse/[twinId]/page.tsx
@@ -23,17 +23,17 @@ export default async function Page(props: Props) {
     showTwin2FaceMode: "DETAILED",
   } as const;
 
-  const result = await safe(
+  const twinResult = await safe(
     withRedirectOnUnauthorized(() =>
       fetchTwinById<Twin_DETAILED>(params.twinId, { header, query })
     )
   );
 
-  if (!result.ok) {
+  if (!twinResult.ok) {
     notFound();
   }
 
-  const { twin, relatedObjects } = result.data;
+  const { twin } = twinResult.data;
 
   if (twin.pageFaceId) {
     return <LayoutRenderer pageFaceId={twin.pageFaceId} twinId={twin.id} />;

--- a/src/app/browse/layout.tsx
+++ b/src/app/browse/layout.tsx
@@ -1,0 +1,9 @@
+import { ReactNode } from "react";
+
+import { PrivateLayoutProviders } from "@/widgets/layout";
+
+export default function Layout({
+  children,
+}: Readonly<{ children: ReactNode }>) {
+  return <PrivateLayoutProviders>{children}</PrivateLayoutProviders>;
+}

--- a/src/app/browse/layout.tsx
+++ b/src/app/browse/layout.tsx
@@ -1,9 +1,0 @@
-import { ReactNode } from "react";
-
-import { PrivateLayoutProviders } from "@/widgets/layout";
-
-export default function Layout({
-  children,
-}: Readonly<{ children: ReactNode }>) {
-  return <PrivateLayoutProviders>{children}</PrivateLayoutProviders>;
-}

--- a/src/app/workspace/[pageKey]/[twinId]/page.tsx
+++ b/src/app/workspace/[pageKey]/[twinId]/page.tsx
@@ -32,7 +32,7 @@ export default async function Page(props: Props) {
     notFound();
   }
 
-  const twin = result.data;
+  const { twin } = result.data;
   if (twin.twinClass?.pageFaceId) {
     return (
       <LayoutRenderer pageFaceId={twin.twinClass.pageFaceId} twinId={twin.id} />

--- a/src/entities/face/api/actions/widget-twidget.ts
+++ b/src/entities/face/api/actions/widget-twidget.ts
@@ -5,6 +5,7 @@ import { isUndefined } from "@/shared/libs";
 
 import { getAuthHeaders } from "../../libs";
 import {
+  FaceBC001ViewRs,
   FaceTC001ViewRs,
   FaceTW001ViewRs,
   FaceTW002ViewRs,
@@ -26,7 +27,8 @@ type FetchFaceOptions = {
     | "/private/face/tw002/{faceId}/v1"
     | "/private/face/tw004/{faceId}/v2"
     | "/private/face/tw005/{faceId}/v1"
-    | "/private/face/tc001/{faceId}/v1";
+    | "/private/face/tc001/{faceId}/v1"
+    | "/private/face/bc001/{faceId}/v1";
   query: Record<string, string>;
 };
 
@@ -175,5 +177,17 @@ export async function fetchTC001Face(
       showTwinClass2TwinClassFieldMode: "DETAILED",
       showTwinClassFieldDescriptor2DataListOptionMode: "DETAILED",
     },
+  });
+}
+
+export async function fetchBC001Face(
+  faceId: string,
+  twinId?: string
+): Promise<FaceBC001ViewRs> {
+  return fetchFace<FaceBC001ViewRs>({
+    faceId,
+    endpoint: "/private/face/bc001/{faceId}/v1",
+    twinId,
+    query: {},
   });
 }

--- a/src/entities/face/api/types.ts
+++ b/src/entities/face/api/types.ts
@@ -51,3 +51,6 @@ export type FaceTW002ViewRs = components["schemas"]["FaceTW002ViewRsV1"];
 export type FaceTW004ViewRs = components["schemas"]["FaceTW004ViewRsV2"];
 export type FaceTW005ViewRs = components["schemas"]["FaceWT005ViewRsV1"];
 export type FaceTC001ViewRs = components["schemas"]["FaceTC001ViewRsV1"];
+// NOTE error it type BE team need to fix
+export type FaceBC001ViewRs = components["schemas"]["FaceBC001ViewRsV1"];
+export type FaceBC001Item = components["schemas"]["FaceBC001ItemV1"];

--- a/src/entities/twin/api/hooks/use-fetch-by-id-v2.ts
+++ b/src/entities/twin/api/hooks/use-fetch-by-id-v2.ts
@@ -13,7 +13,7 @@ export const useTwinFetchByIdV2 = () => {
       setLoading(true);
 
       try {
-        return await fetch<Twin_DETAILED>(id, {
+        const { twin } = await fetch<Twin_DETAILED>(id, {
           header: {
             DomainId: domainId ?? "",
             AuthToken: authToken ?? "",
@@ -32,6 +32,8 @@ export const useTwinFetchByIdV2 = () => {
             showTwin2TransitionMode: "DETAILED",
           },
         });
+
+        return twin;
       } finally {
         setLoading(false);
       }

--- a/src/entities/twin/server/libs/helpers.ts
+++ b/src/entities/twin/server/libs/helpers.ts
@@ -72,18 +72,22 @@ export function hydrateTwinFromMap<T extends Twin_HYDRATED>(
     }, {});
   }
 
-  if (dto.attachments && relatedObjects?.twinClassFieldMap) {
-    const attachmentField = Object.values(
-      relatedObjects.twinClassFieldMap
-    ).find((f) => f.descriptor?.fieldType === "attachmentFieldV1");
+  if (relatedObjects?.twinClassFieldMap) {
+    hydrated.fields = Object.values(relatedObjects.twinClassFieldMap).reduce<
+      Record<string, TwinFieldUI>
+    >((acc, field) => {
+      if (field.descriptor?.fieldType === "attachmentFieldV1") {
+        const attachment = dto.attachments?.find(
+          (att) => att.twinClassFieldId === field.id
+        );
 
-    if (attachmentField) {
-      hydrated.fields = hydrated.fields ?? {};
-      hydrated.fields[attachmentField.key!] = {
-        ...(attachmentField as Required<TwinClassField>),
-        value: dto.attachments[0]?.storageLink ?? "",
-      };
-    }
+        acc[field.key!] = {
+          ...(field as Required<TwinClassField>),
+          value: attachment?.storageLink ?? "",
+        } as TwinFieldUI;
+      }
+      return acc;
+    }, hydrated.fields ?? {});
   }
 
   return hydrated;

--- a/src/features/ui/bread-crumbs.tsx
+++ b/src/features/ui/bread-crumbs.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import { House } from "lucide-react";
+import Link from "next/link";
+import { Fragment } from "react";
+
+import { FaceBC001Item } from "@/entities/face";
+import { PlatformArea } from "@/shared/config";
+import {
+  Breadcrumb,
+  BreadcrumbItem,
+  BreadcrumbList,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+} from "@/shared/ui";
+
+type Props = {
+  items: FaceBC001Item[];
+  activeTwinId: string;
+};
+
+export function BreadCrumbs({ items, activeTwinId }: Props) {
+  return (
+    <Breadcrumb>
+      <BreadcrumbList>
+        <BreadcrumbItem>
+          <Link href="/">
+            <House className="h-4 w-4" />
+          </Link>
+        </BreadcrumbItem>
+        <BreadcrumbSeparator />
+        {items.map((item, index) => {
+          const isActive = item.twinId === activeTwinId;
+          const href =
+            item.label === "Products"
+              ? `/${PlatformArea.workspace}/products`
+              : `/${PlatformArea.browse}/${item.twinId}`;
+
+          return (
+            <Fragment key={item.id}>
+              <BreadcrumbItem>
+                {isActive ? (
+                  <BreadcrumbPage>{item.label}</BreadcrumbPage>
+                ) : (
+                  <Link
+                    href={href}
+                    className={isActive ? "text-foreground font-semibold" : ""}
+                  >
+                    {item.label}
+                  </Link>
+                )}
+              </BreadcrumbItem>
+              {index < items.length - 1 && <BreadcrumbSeparator />}
+            </Fragment>
+          );
+        })}
+      </BreadcrumbList>
+    </Breadcrumb>
+  );
+}

--- a/src/features/ui/bread-crumbs.tsx
+++ b/src/features/ui/bread-crumbs.tsx
@@ -1,11 +1,13 @@
 "use client";
 
 import { House } from "lucide-react";
+import Image from "next/image";
 import Link from "next/link";
 import { Fragment } from "react";
 
 import { FaceBC001Item } from "@/entities/face";
 import { PlatformArea } from "@/shared/config";
+import { isPopulatedString } from "@/shared/libs";
 import {
   Breadcrumb,
   BreadcrumbItem,
@@ -20,6 +22,7 @@ type Props = {
 };
 
 export function BreadCrumbs({ items, activeTwinId }: Props) {
+  console.log("items", items);
   return (
     <Breadcrumb>
       <BreadcrumbList>
@@ -36,16 +39,32 @@ export function BreadCrumbs({ items, activeTwinId }: Props) {
               ? `/${PlatformArea.workspace}/products`
               : `/${PlatformArea.browse}/${item.twinId}`;
 
+          const Icon = isPopulatedString(item.iconUrl)
+            ? () => (
+                <Image
+                  src={item.iconUrl ?? ""}
+                  alt="icon"
+                  width={16}
+                  height={16}
+                  className="mr-2 dark:invert"
+                />
+              )
+            : undefined;
+
           return (
             <Fragment key={item.id}>
               <BreadcrumbItem>
                 {isActive ? (
-                  <BreadcrumbPage>{item.label}</BreadcrumbPage>
+                  <BreadcrumbPage className="flex">
+                    {Icon && <Icon />}
+                    {item.label}
+                  </BreadcrumbPage>
                 ) : (
                   <Link
                     href={href}
-                    className={isActive ? "text-foreground font-semibold" : ""}
+                    className={`flex ${isActive ? "text-foreground font-semibold" : ""}`}
                   >
+                    {Icon && <Icon />}
                     {item.label}
                   </Link>
                 )}

--- a/src/shared/api/generated/schema.d.ts
+++ b/src/shared/api/generated/schema.d.ts
@@ -3863,6 +3863,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/private/face/bc001/{faceId}/v1": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Returns BC001 widget config: breadcrumbs items */
+        get: operations["faceBC001ViewV1"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/private/domain/{domainId}/v1": {
         parameters: {
             query?: never;
@@ -4326,6 +4343,11 @@ export interface components {
             assigneeRequired?: boolean;
             /** @description external id */
             externalId?: string;
+            /**
+             * Format: uuid
+             * @description breadcrumbs face id
+             */
+            breadCrumbsFaceId?: string;
         };
         TwinflowBaseV1: {
             /**
@@ -5420,6 +5442,16 @@ export interface components {
              * @example 608c6d7d-99c8-4d87-89c6-2f72d0f5d673
              */
             ownerUserId?: string;
+            /**
+             * Format: uuid
+             * @description page id
+             */
+            pageFaceId?: string;
+            /**
+             * Format: uuid
+             * @description breadcrumbs face id
+             */
+            breadCrumbsFaceId?: string;
             /** @description status */
             status?: components["schemas"]["TwinStatusV1"];
             /** @description class */
@@ -6038,6 +6070,11 @@ export interface components {
             assigneeRequired?: boolean;
             /** @description external id */
             externalId?: string;
+            /**
+             * Format: uuid
+             * @description breadcrumbs face id
+             */
+            breadCrumbsFaceId?: string;
             /** @description Class fields list */
             fields?: components["schemas"]["TwinClassFieldV1"][];
             /** @description Class fields id list */
@@ -6227,6 +6264,16 @@ export interface components {
              * @example 608c6d7d-99c8-4d87-89c6-2f72d0f5d673
              */
             ownerUserId?: string;
+            /**
+             * Format: uuid
+             * @description page id
+             */
+            pageFaceId?: string;
+            /**
+             * Format: uuid
+             * @description breadcrumbs face id
+             */
+            breadCrumbsFaceId?: string;
             /** @description status */
             status?: components["schemas"]["TwinStatusV1"];
             /** @description class */
@@ -6934,6 +6981,16 @@ export interface components {
              * @example 608c6d7d-99c8-4d87-89c6-2f72d0f5d673
              */
             ownerUserId?: string;
+            /**
+             * Format: uuid
+             * @description page id
+             */
+            pageFaceId?: string;
+            /**
+             * Format: uuid
+             * @description breadcrumbs face id
+             */
+            breadCrumbsFaceId?: string;
         };
         TwinTouchRsV1: {
             /**
@@ -9939,8 +9996,15 @@ export interface components {
              * @description Twin-link class id
              */
             linkId?: string;
-            /** @description Twin dest ids for in(ex)clude from search */
+            /**
+             * @deprecated
+             * @description Twin dest ids for in(ex)clude from search
+             */
             dstTwinIdList?: string[];
+            /** @description Twin src or dest ids for in(ex)clude from search */
+            twinIdList?: string[];
+            /** @description search direction */
+            srcElseDst?: boolean;
         };
         TwinSearchListV1: {
             /** @description match all child twins */
@@ -10744,7 +10808,7 @@ export interface components {
             /** @description twin class */
             twinClass?: components["schemas"]["TwinClassBaseV1"];
         };
-        TwinClassFieldSearchConfiguredRqV1: {
+        TwinClassFieldSearchRqV2: {
             /** @description Search named params values */
             params?: {
                 [key: string]: string;
@@ -10823,10 +10887,6 @@ export interface components {
             pagination?: components["schemas"]["PaginationV1"];
             /** @description results - twin class field list */
             fields?: components["schemas"]["TwinClassFieldV2"][];
-        };
-        TwinClassFieldSearchRqV2: {
-            /** @description search */
-            search?: components["schemas"]["TwinClassFieldSearchV1"];
         };
         TwinClassFieldSearchRqV1: {
             /** @description id list */
@@ -11781,6 +11841,16 @@ export interface components {
              * @example 608c6d7d-99c8-4d87-89c6-2f72d0f5d673
              */
             ownerUserId?: string;
+            /**
+             * Format: uuid
+             * @description page id
+             */
+            pageFaceId?: string;
+            /**
+             * Format: uuid
+             * @description breadcrumbs face id
+             */
+            breadCrumbsFaceId?: string;
             /** @description status */
             status?: components["schemas"]["TwinStatusV1"];
             /** @description class */
@@ -17703,6 +17773,7 @@ export interface components {
             icon?: string;
             /**
              * Format: uuid
+             * @deprecated
              * @description domain navigation bar pointer
              */
             targetPageFaceId?: string;
@@ -17718,6 +17789,11 @@ export interface components {
             parentFaceMenuItemId?: string;
             /** @description children */
             children?: unknown;
+            /**
+             * Format: uuid
+             * @description target twin id
+             */
+            targetTwinId?: string;
         };
         FaceNB001ViewRsV1: {
             /**
@@ -18235,6 +18311,7 @@ export interface operations {
                 showFeaturerParamMode?: "HIDE" | "SHOW";
                 showLinkDst2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
                 showStatusMode?: "HIDE" | "SHORT" | "DETAILED";
+                showTwin2FaceMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2StatusMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
                 showTwin2UserMode?: "HIDE" | "SHORT" | "DETAILED";
@@ -18344,6 +18421,7 @@ export interface operations {
                 lazyRelation?: unknown;
                 showFeaturerParamMode?: "HIDE" | "SHOW";
                 showLinkDst2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
+                showTwin2FaceMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2StatusMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
                 showTwin2UserMode?: "HIDE" | "SHORT" | "DETAILED";
@@ -18411,6 +18489,7 @@ export interface operations {
                 lazyRelation?: unknown;
                 showFeaturerParamMode?: "HIDE" | "SHOW";
                 showLinkDst2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
+                showTwin2FaceMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2StatusMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
                 showTwin2UserMode?: "HIDE" | "SHORT" | "DETAILED";
@@ -18562,6 +18641,7 @@ export interface operations {
                 lazyRelation?: unknown;
                 showFeaturerParamMode?: "HIDE" | "SHOW";
                 showLinkDst2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
+                showTwin2FaceMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2StatusMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
                 showTwin2UserMode?: "HIDE" | "SHORT" | "DETAILED";
@@ -18625,6 +18705,7 @@ export interface operations {
                 lazyRelation?: unknown;
                 showFeaturerParamMode?: "HIDE" | "SHOW";
                 showLinkDst2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
+                showTwin2FaceMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2StatusMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
                 showTwin2UserMode?: "HIDE" | "SHORT" | "DETAILED";
@@ -18732,6 +18813,7 @@ export interface operations {
                 lazyRelation?: unknown;
                 showFeaturerParamMode?: "HIDE" | "SHOW";
                 showLinkDst2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
+                showTwin2FaceMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2StatusMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
                 showTwin2UserMode?: "HIDE" | "SHORT" | "DETAILED";
@@ -18807,6 +18889,7 @@ export interface operations {
                 showLinkDst2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
                 showTwin2AttachmentCollectionMode?: "DIRECT" | "FROM_TRANSITIONS" | "FROM_COMMENTS" | "FROM_FIELDS" | "ALL";
                 showTwin2AttachmentMode?: "HIDE" | "SHORT" | "DETAILED";
+                showTwin2FaceMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2StatusMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2TransitionMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
                 showTwin2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
@@ -18896,6 +18979,7 @@ export interface operations {
                 showLinkDst2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
                 showTwin2AttachmentCollectionMode?: "DIRECT" | "FROM_TRANSITIONS" | "FROM_COMMENTS" | "FROM_FIELDS" | "ALL";
                 showTwin2AttachmentMode?: "HIDE" | "SHORT" | "DETAILED";
+                showTwin2FaceMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2StatusMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2TransitionMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
                 showTwin2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
@@ -19205,6 +19289,7 @@ export interface operations {
                 showPermissionGrantUserGroup2UserMode?: "HIDE" | "SHORT" | "DETAILED";
                 showPermissionGrantUserGroupMode?: "HIDE" | "SHORT" | "DETAILED";
                 showPermissionGroup2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
+                showTwin2FaceMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2StatusMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
                 showTwin2UserMode?: "HIDE" | "SHORT" | "DETAILED";
@@ -19414,6 +19499,7 @@ export interface operations {
                 showPermissionGrantTwinRole2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
                 showPermissionGrantTwinRole2UserMode?: "HIDE" | "SHORT" | "DETAILED";
                 showPermissionGrantTwinRoleMode?: "HIDE" | "SHORT" | "DETAILED";
+                showTwin2FaceMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2StatusMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
                 showTwin2UserMode?: "HIDE" | "SHORT" | "DETAILED";
@@ -19529,6 +19615,7 @@ export interface operations {
                 showPermissionGroup2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
                 showSpaceRole2BusinessAccountMode?: "HIDE" | "SHORT" | "DETAILED";
                 showSpaceRole2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
+                showTwin2FaceMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2StatusMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
                 showTwin2UserMode?: "HIDE" | "SHORT" | "DETAILED";
@@ -19643,6 +19730,7 @@ export interface operations {
                 showPermissionGrantAssigneePropagationMode?: "HIDE" | "SHORT" | "DETAILED";
                 showPermissionGroup2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
                 showPropagationTwinStatus2StatusMode?: "HIDE" | "SHORT" | "DETAILED";
+                showTwin2FaceMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2StatusMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
                 showTwin2UserMode?: "HIDE" | "SHORT" | "DETAILED";
@@ -19713,6 +19801,7 @@ export interface operations {
                 showLinkDst2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
                 showLinkMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
                 showLinkSrc2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
+                showTwin2FaceMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2StatusMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
                 showTwin2UserMode?: "HIDE" | "SHORT" | "DETAILED";
@@ -19779,6 +19868,7 @@ export interface operations {
                 showLinkDst2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
                 showLinkMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
                 showLinkSrc2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
+                showTwin2FaceMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2StatusMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
                 showTwin2UserMode?: "HIDE" | "SHORT" | "DETAILED";
@@ -20747,6 +20837,7 @@ export interface operations {
                 showStatusMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2AttachmentCollectionMode?: "DIRECT" | "FROM_TRANSITIONS" | "FROM_COMMENTS" | "FROM_FIELDS" | "ALL";
                 showTwin2AttachmentMode?: "HIDE" | "SHORT" | "DETAILED";
+                showTwin2FaceMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2StatusMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2TransitionMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
                 showTwin2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
@@ -20837,6 +20928,7 @@ export interface operations {
                 showStatusMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2AttachmentCollectionMode?: "DIRECT" | "FROM_TRANSITIONS" | "FROM_COMMENTS" | "FROM_FIELDS" | "ALL";
                 showTwin2AttachmentMode?: "HIDE" | "SHORT" | "DETAILED";
+                showTwin2FaceMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2StatusMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2TransitionMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
                 showTwin2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
@@ -21562,6 +21654,7 @@ export interface operations {
                 showFeaturerParamMode?: "HIDE" | "SHOW";
                 showLinkDst2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
                 showStatusMode?: "HIDE" | "SHORT" | "DETAILED";
+                showTwin2FaceMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2StatusMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
                 showTwin2UserMode?: "HIDE" | "SHORT" | "DETAILED";
@@ -21630,6 +21723,7 @@ export interface operations {
                 lazyRelation?: unknown;
                 showFeaturerParamMode?: "HIDE" | "SHOW";
                 showLinkDst2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
+                showTwin2FaceMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2StatusMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
                 showTwin2UserMode?: "HIDE" | "SHORT" | "DETAILED";
@@ -21674,7 +21768,7 @@ export interface operations {
         };
         requestBody: {
             content: {
-                "application/json": components["schemas"]["TwinClassFieldSearchConfiguredRqV1"];
+                "application/json": components["schemas"]["TwinClassFieldSearchRqV2"];
             };
         };
         responses: {
@@ -21704,6 +21798,7 @@ export interface operations {
                 lazyRelation?: unknown;
                 showFeaturerParamMode?: "HIDE" | "SHOW";
                 showLinkDst2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
+                showTwin2FaceMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2StatusMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
                 showTwin2UserMode?: "HIDE" | "SHORT" | "DETAILED";
@@ -21775,6 +21870,7 @@ export interface operations {
                 lazyRelation?: unknown;
                 showFeaturerParamMode?: "HIDE" | "SHOW";
                 showLinkDst2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
+                showTwin2FaceMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2StatusMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
                 showTwin2UserMode?: "HIDE" | "SHORT" | "DETAILED";
@@ -21857,6 +21953,7 @@ export interface operations {
                 showLinkDst2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
                 showTwin2AttachmentCollectionMode?: "DIRECT" | "FROM_TRANSITIONS" | "FROM_COMMENTS" | "FROM_FIELDS" | "ALL";
                 showTwin2AttachmentMode?: "HIDE" | "SHORT" | "DETAILED";
+                showTwin2FaceMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2StatusMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2TransitionMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
                 showTwin2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
@@ -22103,6 +22200,7 @@ export interface operations {
                 showLinkDst2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
                 showTwin2AttachmentCollectionMode?: "DIRECT" | "FROM_TRANSITIONS" | "FROM_COMMENTS" | "FROM_FIELDS" | "ALL";
                 showTwin2AttachmentMode?: "HIDE" | "SHORT" | "DETAILED";
+                showTwin2FaceMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2StatusMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2TransitionMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
                 showTwin2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
@@ -22194,6 +22292,7 @@ export interface operations {
                 lazyRelation?: unknown;
                 showFeaturerParamMode?: "HIDE" | "SHOW";
                 showLinkDst2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
+                showTwin2FaceMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2StatusMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
                 showTwin2UserMode?: "HIDE" | "SHORT" | "DETAILED";
@@ -22265,6 +22364,7 @@ export interface operations {
                 lazyRelation?: unknown;
                 showFeaturerParamMode?: "HIDE" | "SHOW";
                 showLinkDst2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
+                showTwin2FaceMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2StatusMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
                 showTwin2UserMode?: "HIDE" | "SHORT" | "DETAILED";
@@ -22332,6 +22432,7 @@ export interface operations {
                 lazyRelation?: unknown;
                 showFeaturerParamMode?: "HIDE" | "SHOW";
                 showLinkDst2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
+                showTwin2FaceMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2StatusMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
                 showTwin2UserMode?: "HIDE" | "SHORT" | "DETAILED";
@@ -22396,6 +22497,7 @@ export interface operations {
                 lazyRelation?: unknown;
                 showFeaturerParamMode?: "HIDE" | "SHOW";
                 showLinkDst2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
+                showTwin2FaceMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2StatusMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
                 showTwin2UserMode?: "HIDE" | "SHORT" | "DETAILED";
@@ -22466,6 +22568,7 @@ export interface operations {
                 lazyRelation?: unknown;
                 showFeaturerParamMode?: "HIDE" | "SHOW";
                 showLinkDst2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
+                showTwin2FaceMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2StatusMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
                 showTwin2UserMode?: "HIDE" | "SHORT" | "DETAILED";
@@ -22533,6 +22636,7 @@ export interface operations {
                 lazyRelation?: unknown;
                 showFeaturerParamMode?: "HIDE" | "SHOW";
                 showLinkDst2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
+                showTwin2FaceMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2StatusMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
                 showTwin2UserMode?: "HIDE" | "SHORT" | "DETAILED";
@@ -22611,6 +22715,7 @@ export interface operations {
                 showLinkDst2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
                 showTwin2AttachmentCollectionMode?: "DIRECT" | "FROM_TRANSITIONS" | "FROM_COMMENTS" | "FROM_FIELDS" | "ALL";
                 showTwin2AttachmentMode?: "HIDE" | "SHORT" | "DETAILED";
+                showTwin2FaceMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2StatusMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2TransitionMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
                 showTwin2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
@@ -22709,6 +22814,7 @@ export interface operations {
                 showSpaceRoleUserGroup2SpaceRoleMode?: "HIDE" | "SHORT" | "DETAILED";
                 showSpaceRoleUserGroupMode?: "HIDE" | "SHORT" | "DETAILED";
                 showSpaceRoleUserMode?: "HIDE" | "SHORT" | "DETAILED";
+                showTwin2FaceMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2StatusMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
                 showTwin2UserMode?: "HIDE" | "SHORT" | "DETAILED";
@@ -22787,6 +22893,7 @@ export interface operations {
                 showLinkDst2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
                 showTwin2AttachmentCollectionMode?: "DIRECT" | "FROM_TRANSITIONS" | "FROM_COMMENTS" | "FROM_FIELDS" | "ALL";
                 showTwin2AttachmentMode?: "HIDE" | "SHORT" | "DETAILED";
+                showTwin2FaceMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2StatusMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2TransitionMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
                 showTwin2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
@@ -22932,6 +23039,7 @@ export interface operations {
                 showLinkDst2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
                 showTwin2AttachmentCollectionMode?: "DIRECT" | "FROM_TRANSITIONS" | "FROM_COMMENTS" | "FROM_FIELDS" | "ALL";
                 showTwin2AttachmentMode?: "HIDE" | "SHORT" | "DETAILED";
+                showTwin2FaceMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2StatusMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2TransitionMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
                 showTwin2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
@@ -23061,6 +23169,7 @@ export interface operations {
             query?: {
                 showFeaturerParamMode?: "HIDE" | "SHOW";
                 showLinkDst2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
+                showTwin2FaceMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2StatusMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
                 showTwin2UserMode?: "HIDE" | "SHORT" | "DETAILED";
@@ -23359,6 +23468,7 @@ export interface operations {
                 showLinkDst2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
                 showTwin2AttachmentCollectionMode?: "DIRECT" | "FROM_TRANSITIONS" | "FROM_COMMENTS" | "FROM_FIELDS" | "ALL";
                 showTwin2AttachmentMode?: "HIDE" | "SHORT" | "DETAILED";
+                showTwin2FaceMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2StatusMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2TransitionMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
                 showTwin2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
@@ -23499,6 +23609,7 @@ export interface operations {
                 showLinkDst2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
                 showTwin2AttachmentCollectionMode?: "DIRECT" | "FROM_TRANSITIONS" | "FROM_COMMENTS" | "FROM_FIELDS" | "ALL";
                 showTwin2AttachmentMode?: "HIDE" | "SHORT" | "DETAILED";
+                showTwin2FaceMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2StatusMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2TransitionMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
                 showTwin2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
@@ -23599,6 +23710,7 @@ export interface operations {
                 showLinkDst2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
                 showTwin2AttachmentCollectionMode?: "DIRECT" | "FROM_TRANSITIONS" | "FROM_COMMENTS" | "FROM_FIELDS" | "ALL";
                 showTwin2AttachmentMode?: "HIDE" | "SHORT" | "DETAILED";
+                showTwin2FaceMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2StatusMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2TransitionMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
                 showTwin2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
@@ -23696,6 +23808,7 @@ export interface operations {
                 showLinkDst2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
                 showTwin2AttachmentCollectionMode?: "DIRECT" | "FROM_TRANSITIONS" | "FROM_COMMENTS" | "FROM_FIELDS" | "ALL";
                 showTwin2AttachmentMode?: "HIDE" | "SHORT" | "DETAILED";
+                showTwin2FaceMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2StatusMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2TransitionMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
                 showTwin2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
@@ -23793,6 +23906,7 @@ export interface operations {
                 showLinkDst2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
                 showTwin2AttachmentCollectionMode?: "DIRECT" | "FROM_TRANSITIONS" | "FROM_COMMENTS" | "FROM_FIELDS" | "ALL";
                 showTwin2AttachmentMode?: "HIDE" | "SHORT" | "DETAILED";
+                showTwin2FaceMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2StatusMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2TransitionMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
                 showTwin2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
@@ -23962,6 +24076,7 @@ export interface operations {
                 showHistory2TwinMode?: "HIDE" | "SHORT" | "DETAILED";
                 showHistory2UserMode?: "HIDE" | "SHORT" | "DETAILED";
                 showLinkDst2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
+                showTwin2FaceMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2StatusMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
                 showTwin2UserMode?: "HIDE" | "SHORT" | "DETAILED";
@@ -24130,6 +24245,7 @@ export interface operations {
                 showTransitionResultMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2AttachmentCollectionMode?: "DIRECT" | "FROM_TRANSITIONS" | "FROM_COMMENTS" | "FROM_FIELDS" | "ALL";
                 showTwin2AttachmentMode?: "HIDE" | "SHORT" | "DETAILED";
+                showTwin2FaceMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2StatusMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2TransitionMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
                 showTwin2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
@@ -24231,6 +24347,7 @@ export interface operations {
                 showTransitionResultMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2AttachmentCollectionMode?: "DIRECT" | "FROM_TRANSITIONS" | "FROM_COMMENTS" | "FROM_FIELDS" | "ALL";
                 showTwin2AttachmentMode?: "HIDE" | "SHORT" | "DETAILED";
+                showTwin2FaceMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2StatusMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2TransitionMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
                 showTwin2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
@@ -24331,6 +24448,7 @@ export interface operations {
                 showTransitionResultMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2AttachmentCollectionMode?: "DIRECT" | "FROM_TRANSITIONS" | "FROM_COMMENTS" | "FROM_FIELDS" | "ALL";
                 showTwin2AttachmentMode?: "HIDE" | "SHORT" | "DETAILED";
+                showTwin2FaceMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2StatusMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2TransitionMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
                 showTwin2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
@@ -24432,6 +24550,7 @@ export interface operations {
                 showTransitionResultMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2AttachmentCollectionMode?: "DIRECT" | "FROM_TRANSITIONS" | "FROM_COMMENTS" | "FROM_FIELDS" | "ALL";
                 showTwin2AttachmentMode?: "HIDE" | "SHORT" | "DETAILED";
+                showTwin2FaceMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2StatusMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2TransitionMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
                 showTwin2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
@@ -24795,6 +24914,7 @@ export interface operations {
                 showTransitionResultMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2AttachmentCollectionMode?: "DIRECT" | "FROM_TRANSITIONS" | "FROM_COMMENTS" | "FROM_FIELDS" | "ALL";
                 showTwin2AttachmentMode?: "HIDE" | "SHORT" | "DETAILED";
+                showTwin2FaceMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2StatusMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2TransitionMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
                 showTwin2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
@@ -24896,6 +25016,7 @@ export interface operations {
                 showTransitionResultMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2AttachmentCollectionMode?: "DIRECT" | "FROM_TRANSITIONS" | "FROM_COMMENTS" | "FROM_FIELDS" | "ALL";
                 showTwin2AttachmentMode?: "HIDE" | "SHORT" | "DETAILED";
+                showTwin2FaceMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2StatusMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2TransitionMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
                 showTwin2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
@@ -24996,6 +25117,7 @@ export interface operations {
                 showTransitionResultMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2AttachmentCollectionMode?: "DIRECT" | "FROM_TRANSITIONS" | "FROM_COMMENTS" | "FROM_FIELDS" | "ALL";
                 showTwin2AttachmentMode?: "HIDE" | "SHORT" | "DETAILED";
+                showTwin2FaceMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2StatusMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2TransitionMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
                 showTwin2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
@@ -25097,6 +25219,7 @@ export interface operations {
                 showTransitionResultMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2AttachmentCollectionMode?: "DIRECT" | "FROM_TRANSITIONS" | "FROM_COMMENTS" | "FROM_FIELDS" | "ALL";
                 showTwin2AttachmentMode?: "HIDE" | "SHORT" | "DETAILED";
+                showTwin2FaceMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2StatusMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2TransitionMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
                 showTwin2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
@@ -25436,6 +25559,7 @@ export interface operations {
                 showSpaceRole2BusinessAccountMode?: "HIDE" | "SHORT" | "DETAILED";
                 showSpaceRole2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
                 showSpaceRoleMode?: "HIDE" | "SHORT" | "DETAILED";
+                showTwin2FaceMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2StatusMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
                 showTwin2UserMode?: "HIDE" | "SHORT" | "DETAILED";
@@ -25507,6 +25631,7 @@ export interface operations {
                 showSpaceRole2BusinessAccountMode?: "HIDE" | "SHORT" | "DETAILED";
                 showSpaceRole2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
                 showSpaceRoleMode?: "HIDE" | "SHORT" | "DETAILED";
+                showTwin2FaceMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2StatusMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
                 showTwin2UserMode?: "HIDE" | "SHORT" | "DETAILED";
@@ -25724,6 +25849,7 @@ export interface operations {
                 showLinkDst2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
                 showPermissionGroup2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
                 showPermissionGroupMode?: "HIDE" | "SHORT" | "DETAILED";
+                showTwin2FaceMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2StatusMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
                 showTwin2UserMode?: "HIDE" | "SHORT" | "DETAILED";
@@ -25798,6 +25924,7 @@ export interface operations {
                 showPermissionGrantUserGroup2UserMode?: "HIDE" | "SHORT" | "DETAILED";
                 showPermissionGrantUserGroupMode?: "HIDE" | "SHORT" | "DETAILED";
                 showPermissionGroup2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
+                showTwin2FaceMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2StatusMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
                 showTwin2UserMode?: "HIDE" | "SHORT" | "DETAILED";
@@ -25869,6 +25996,7 @@ export interface operations {
                 showPermissionGrantUserGroup2UserMode?: "HIDE" | "SHORT" | "DETAILED";
                 showPermissionGrantUserGroupMode?: "HIDE" | "SHORT" | "DETAILED";
                 showPermissionGroup2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
+                showTwin2FaceMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2StatusMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
                 showTwin2UserMode?: "HIDE" | "SHORT" | "DETAILED";
@@ -25942,6 +26070,7 @@ export interface operations {
                 showPermissionGrantUser2UserMode?: "HIDE" | "SHORT" | "DETAILED";
                 showPermissionGrantUserMode?: "HIDE" | "SHORT" | "DETAILED";
                 showPermissionGroup2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
+                showTwin2FaceMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2StatusMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
                 showTwin2UserMode?: "HIDE" | "SHORT" | "DETAILED";
@@ -26067,6 +26196,7 @@ export interface operations {
                 showPermissionGrantUser2UserMode?: "HIDE" | "SHORT" | "DETAILED";
                 showPermissionGrantUserMode?: "HIDE" | "SHORT" | "DETAILED";
                 showPermissionGroup2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
+                showTwin2FaceMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2StatusMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
                 showTwin2UserMode?: "HIDE" | "SHORT" | "DETAILED";
@@ -26139,6 +26269,7 @@ export interface operations {
                 showPermissionGrantTwinRole2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
                 showPermissionGrantTwinRole2UserMode?: "HIDE" | "SHORT" | "DETAILED";
                 showPermissionGrantTwinRoleMode?: "HIDE" | "SHORT" | "DETAILED";
+                showTwin2FaceMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2StatusMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
                 showTwin2UserMode?: "HIDE" | "SHORT" | "DETAILED";
@@ -26208,6 +26339,7 @@ export interface operations {
                 showPermissionGrantTwinRole2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
                 showPermissionGrantTwinRole2UserMode?: "HIDE" | "SHORT" | "DETAILED";
                 showPermissionGrantTwinRoleMode?: "HIDE" | "SHORT" | "DETAILED";
+                showTwin2FaceMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2StatusMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
                 showTwin2UserMode?: "HIDE" | "SHORT" | "DETAILED";
@@ -26284,6 +26416,7 @@ export interface operations {
                 showPermissionGroup2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
                 showSpaceRole2BusinessAccountMode?: "HIDE" | "SHORT" | "DETAILED";
                 showSpaceRole2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
+                showTwin2FaceMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2StatusMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
                 showTwin2UserMode?: "HIDE" | "SHORT" | "DETAILED";
@@ -26357,6 +26490,7 @@ export interface operations {
                 showPermissionGroup2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
                 showSpaceRole2BusinessAccountMode?: "HIDE" | "SHORT" | "DETAILED";
                 showSpaceRole2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
+                showTwin2FaceMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2StatusMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
                 showTwin2UserMode?: "HIDE" | "SHORT" | "DETAILED";
@@ -26432,6 +26566,7 @@ export interface operations {
                 showPermissionGrantAssigneePropagationMode?: "HIDE" | "SHORT" | "DETAILED";
                 showPermissionGroup2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
                 showPropagationTwinStatus2StatusMode?: "HIDE" | "SHORT" | "DETAILED";
+                showTwin2FaceMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2StatusMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
                 showTwin2UserMode?: "HIDE" | "SHORT" | "DETAILED";
@@ -26504,6 +26639,7 @@ export interface operations {
                 showPermissionGrantAssigneePropagationMode?: "HIDE" | "SHORT" | "DETAILED";
                 showPermissionGroup2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
                 showPropagationTwinStatus2StatusMode?: "HIDE" | "SHORT" | "DETAILED";
+                showTwin2FaceMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2StatusMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
                 showTwin2UserMode?: "HIDE" | "SHORT" | "DETAILED";
@@ -26574,6 +26710,7 @@ export interface operations {
                 showPermission2PermissionGroupMode?: "HIDE" | "SHORT" | "DETAILED";
                 showPermissionGroup2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
                 showPermissionMode?: "HIDE" | "SHORT" | "DETAILED";
+                showTwin2FaceMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2StatusMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
                 showTwin2UserMode?: "HIDE" | "SHORT" | "DETAILED";
@@ -26727,6 +26864,7 @@ export interface operations {
                 showPermission2PermissionGroupMode?: "HIDE" | "SHORT" | "DETAILED";
                 showPermissionGroup2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
                 showPermissionMode?: "HIDE" | "SHORT" | "DETAILED";
+                showTwin2FaceMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2StatusMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
                 showTwin2UserMode?: "HIDE" | "SHORT" | "DETAILED";
@@ -26797,6 +26935,7 @@ export interface operations {
                 showLinkDst2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
                 showLinkMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
                 showLinkSrc2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
+                showTwin2FaceMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2StatusMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
                 showTwin2UserMode?: "HIDE" | "SHORT" | "DETAILED";
@@ -26864,6 +27003,7 @@ export interface operations {
                 showLinkDst2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
                 showLinkMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
                 showLinkSrc2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
+                showTwin2FaceMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2StatusMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
                 showTwin2UserMode?: "HIDE" | "SHORT" | "DETAILED";
@@ -28431,6 +28571,7 @@ export interface operations {
                 showStatusMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2AttachmentCollectionMode?: "DIRECT" | "FROM_TRANSITIONS" | "FROM_COMMENTS" | "FROM_FIELDS" | "ALL";
                 showTwin2AttachmentMode?: "HIDE" | "SHORT" | "DETAILED";
+                showTwin2FaceMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2StatusMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2TransitionMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
                 showTwin2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
@@ -28571,6 +28712,7 @@ export interface operations {
                 showStatusMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2AttachmentCollectionMode?: "DIRECT" | "FROM_TRANSITIONS" | "FROM_COMMENTS" | "FROM_FIELDS" | "ALL";
                 showTwin2AttachmentMode?: "HIDE" | "SHORT" | "DETAILED";
+                showTwin2FaceMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2StatusMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2TransitionMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
                 showTwin2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
@@ -28706,6 +28848,7 @@ export interface operations {
                 showStatusMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2AttachmentCollectionMode?: "DIRECT" | "FROM_TRANSITIONS" | "FROM_COMMENTS" | "FROM_FIELDS" | "ALL";
                 showTwin2AttachmentMode?: "HIDE" | "SHORT" | "DETAILED";
+                showTwin2FaceMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2StatusMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2TransitionMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
                 showTwin2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
@@ -28847,6 +28990,7 @@ export interface operations {
                 showStatusMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2AttachmentCollectionMode?: "DIRECT" | "FROM_TRANSITIONS" | "FROM_COMMENTS" | "FROM_FIELDS" | "ALL";
                 showTwin2AttachmentMode?: "HIDE" | "SHORT" | "DETAILED";
+                showTwin2FaceMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2StatusMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2TransitionMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
                 showTwin2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
@@ -29631,6 +29775,7 @@ export interface operations {
                 showPermissionGroup2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
                 showPermissionGroupMode?: "HIDE" | "SHORT" | "DETAILED";
                 showPermissionMode?: "HIDE" | "SHORT" | "DETAILED";
+                showTwin2FaceMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2StatusMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
                 showTwin2UserMode?: "HIDE" | "SHORT" | "DETAILED";
@@ -29697,6 +29842,7 @@ export interface operations {
                 showPermission2PermissionGroupMode?: "HIDE" | "SHORT" | "DETAILED";
                 showPermissionGroup2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
                 showPermissionMode?: "HIDE" | "SHORT" | "DETAILED";
+                showTwin2FaceMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2StatusMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
                 showTwin2UserMode?: "HIDE" | "SHORT" | "DETAILED";
@@ -29762,6 +29908,7 @@ export interface operations {
                 showPermissionGroup2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
                 showPermissionGroupMode?: "HIDE" | "SHORT" | "DETAILED";
                 showPermissionMode?: "HIDE" | "SHORT" | "DETAILED";
+                showTwin2FaceMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2StatusMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
                 showTwin2UserMode?: "HIDE" | "SHORT" | "DETAILED";
@@ -29825,6 +29972,7 @@ export interface operations {
                 showPermission2PermissionGroupMode?: "HIDE" | "SHORT" | "DETAILED";
                 showPermissionGroup2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
                 showPermissionMode?: "HIDE" | "SHORT" | "DETAILED";
+                showTwin2FaceMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2StatusMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
                 showTwin2UserMode?: "HIDE" | "SHORT" | "DETAILED";
@@ -29965,6 +30113,7 @@ export interface operations {
                 lazyRelation?: unknown;
                 showFeaturerParamMode?: "HIDE" | "SHOW";
                 showLinkDst2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
+                showTwin2FaceMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2StatusMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
                 showTwin2UserMode?: "HIDE" | "SHORT" | "DETAILED";
@@ -30028,6 +30177,7 @@ export interface operations {
                 lazyRelation?: unknown;
                 showFeaturerParamMode?: "HIDE" | "SHOW";
                 showLinkDst2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
+                showTwin2FaceMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2StatusMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
                 showTwin2UserMode?: "HIDE" | "SHORT" | "DETAILED";
@@ -30134,6 +30284,7 @@ export interface operations {
                 showFeaturerParamMode?: "HIDE" | "SHOW";
                 showLinkDst2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
                 showLinkMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
+                showTwin2FaceMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2StatusMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
                 showTwin2UserMode?: "HIDE" | "SHORT" | "DETAILED";
@@ -30197,6 +30348,7 @@ export interface operations {
                 lazyRelation?: unknown;
                 showFeaturerParamMode?: "HIDE" | "SHOW";
                 showLinkDst2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
+                showTwin2FaceMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2StatusMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
                 showTwin2UserMode?: "HIDE" | "SHORT" | "DETAILED";
@@ -30306,6 +30458,7 @@ export interface operations {
                 lazyRelation?: unknown;
                 showFeaturerParamMode?: "HIDE" | "SHOW";
                 showLinkDst2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
+                showTwin2FaceMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2StatusMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
                 showTwin2UserMode?: "HIDE" | "SHORT" | "DETAILED";
@@ -30380,6 +30533,7 @@ export interface operations {
                 showLinkDst2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
                 showTwin2AttachmentCollectionMode?: "DIRECT" | "FROM_TRANSITIONS" | "FROM_COMMENTS" | "FROM_FIELDS" | "ALL";
                 showTwin2AttachmentMode?: "HIDE" | "SHORT" | "DETAILED";
+                showTwin2FaceMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2StatusMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2TransitionMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
                 showTwin2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
@@ -30469,6 +30623,7 @@ export interface operations {
                 showLinkDst2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
                 showTwin2AttachmentCollectionMode?: "DIRECT" | "FROM_TRANSITIONS" | "FROM_COMMENTS" | "FROM_FIELDS" | "ALL";
                 showTwin2AttachmentMode?: "HIDE" | "SHORT" | "DETAILED";
+                showTwin2FaceMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2StatusMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2TransitionMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
                 showTwin2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
@@ -30558,6 +30713,7 @@ export interface operations {
                 showLinkDst2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
                 showTwin2AttachmentCollectionMode?: "DIRECT" | "FROM_TRANSITIONS" | "FROM_COMMENTS" | "FROM_FIELDS" | "ALL";
                 showTwin2AttachmentMode?: "HIDE" | "SHORT" | "DETAILED";
+                showTwin2FaceMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2StatusMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2TransitionMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
                 showTwin2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
@@ -30643,6 +30799,7 @@ export interface operations {
                 showHistory2TwinMode?: "HIDE" | "SHORT" | "DETAILED";
                 showHistory2UserMode?: "HIDE" | "SHORT" | "DETAILED";
                 showLinkDst2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
+                showTwin2FaceMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2StatusMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
                 showTwin2UserMode?: "HIDE" | "SHORT" | "DETAILED";
@@ -30711,6 +30868,7 @@ export interface operations {
                 showHistory2TwinMode?: "HIDE" | "SHORT" | "DETAILED";
                 showHistory2UserMode?: "HIDE" | "SHORT" | "DETAILED";
                 showLinkDst2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
+                showTwin2FaceMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2StatusMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
                 showTwin2UserMode?: "HIDE" | "SHORT" | "DETAILED";
@@ -30852,6 +31010,7 @@ export interface operations {
                 showSpaceRole2BusinessAccountMode?: "HIDE" | "SHORT" | "DETAILED";
                 showSpaceRole2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
                 showSpaceRoleMode?: "HIDE" | "SHORT" | "DETAILED";
+                showTwin2FaceMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2StatusMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
                 showTwin2UserMode?: "HIDE" | "SHORT" | "DETAILED";
@@ -30921,6 +31080,7 @@ export interface operations {
                 showSpaceRole2BusinessAccountMode?: "HIDE" | "SHORT" | "DETAILED";
                 showSpaceRole2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
                 showSpaceRoleMode?: "HIDE" | "SHORT" | "DETAILED";
+                showTwin2FaceMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2StatusMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
                 showTwin2UserMode?: "HIDE" | "SHORT" | "DETAILED";
@@ -31078,6 +31238,7 @@ export interface operations {
                 showLinkDst2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
                 showPermissionGroup2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
                 showPermissionGroupMode?: "HIDE" | "SHORT" | "DETAILED";
+                showTwin2FaceMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2StatusMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
                 showTwin2UserMode?: "HIDE" | "SHORT" | "DETAILED";
@@ -31143,6 +31304,7 @@ export interface operations {
                 showLinkDst2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
                 showPermissionGroup2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
                 showPermissionGroupMode?: "HIDE" | "SHORT" | "DETAILED";
+                showTwin2FaceMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2StatusMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
                 showTwin2UserMode?: "HIDE" | "SHORT" | "DETAILED";
@@ -31213,6 +31375,7 @@ export interface operations {
                 showPermissionGrantUserGroup2UserMode?: "HIDE" | "SHORT" | "DETAILED";
                 showPermissionGrantUserGroupMode?: "HIDE" | "SHORT" | "DETAILED";
                 showPermissionGroup2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
+                showTwin2FaceMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2StatusMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
                 showTwin2UserMode?: "HIDE" | "SHORT" | "DETAILED";
@@ -31281,6 +31444,7 @@ export interface operations {
                 showPermissionGrantTwinRole2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
                 showPermissionGrantTwinRole2UserMode?: "HIDE" | "SHORT" | "DETAILED";
                 showPermissionGrantTwinRoleMode?: "HIDE" | "SHORT" | "DETAILED";
+                showTwin2FaceMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2StatusMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
                 showTwin2UserMode?: "HIDE" | "SHORT" | "DETAILED";
@@ -31353,6 +31517,7 @@ export interface operations {
                 showPermissionGroup2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
                 showSpaceRole2BusinessAccountMode?: "HIDE" | "SHORT" | "DETAILED";
                 showSpaceRole2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
+                showTwin2FaceMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2StatusMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
                 showTwin2UserMode?: "HIDE" | "SHORT" | "DETAILED";
@@ -31424,6 +31589,7 @@ export interface operations {
                 showPermissionGrantAssigneePropagationMode?: "HIDE" | "SHORT" | "DETAILED";
                 showPermissionGroup2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
                 showPropagationTwinStatus2StatusMode?: "HIDE" | "SHORT" | "DETAILED";
+                showTwin2FaceMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2StatusMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
                 showTwin2UserMode?: "HIDE" | "SHORT" | "DETAILED";
@@ -31490,6 +31656,7 @@ export interface operations {
                 showPermission2PermissionGroupMode?: "HIDE" | "SHORT" | "DETAILED";
                 showPermissionGroup2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
                 showPermissionMode?: "HIDE" | "SHORT" | "DETAILED";
+                showTwin2FaceMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2StatusMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
                 showTwin2UserMode?: "HIDE" | "SHORT" | "DETAILED";
@@ -32063,6 +32230,7 @@ export interface operations {
                 showFeaturerParamMode?: "HIDE" | "SHOW";
                 showLinkDst2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
                 showModalFace2FaceMode?: "HIDE" | "SHORT" | "DETAILED";
+                showTwin2FaceMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2StatusMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
                 showTwin2UserMode?: "HIDE" | "SHORT" | "DETAILED";
@@ -32141,6 +32309,7 @@ export interface operations {
                 showLinkDst2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
                 showTwin2AttachmentCollectionMode?: "DIRECT" | "FROM_TRANSITIONS" | "FROM_COMMENTS" | "FROM_FIELDS" | "ALL";
                 showTwin2AttachmentMode?: "HIDE" | "SHORT" | "DETAILED";
+                showTwin2FaceMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2StatusMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2TransitionMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
                 showTwin2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
@@ -32233,6 +32402,7 @@ export interface operations {
                 showLinkDst2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
                 showTwin2AttachmentCollectionMode?: "DIRECT" | "FROM_TRANSITIONS" | "FROM_COMMENTS" | "FROM_FIELDS" | "ALL";
                 showTwin2AttachmentMode?: "HIDE" | "SHORT" | "DETAILED";
+                showTwin2FaceMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2StatusMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2TransitionMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
                 showTwin2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
@@ -32325,6 +32495,7 @@ export interface operations {
                 showLinkDst2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
                 showTwin2AttachmentCollectionMode?: "DIRECT" | "FROM_TRANSITIONS" | "FROM_COMMENTS" | "FROM_FIELDS" | "ALL";
                 showTwin2AttachmentMode?: "HIDE" | "SHORT" | "DETAILED";
+                showTwin2FaceMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2StatusMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2TransitionMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
                 showTwin2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
@@ -32417,6 +32588,7 @@ export interface operations {
                 showLinkDst2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
                 showTwin2AttachmentCollectionMode?: "DIRECT" | "FROM_TRANSITIONS" | "FROM_COMMENTS" | "FROM_FIELDS" | "ALL";
                 showTwin2AttachmentMode?: "HIDE" | "SHORT" | "DETAILED";
+                showTwin2FaceMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2StatusMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2TransitionMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
                 showTwin2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
@@ -32510,6 +32682,7 @@ export interface operations {
                 showLinkDst2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
                 showTwin2AttachmentCollectionMode?: "DIRECT" | "FROM_TRANSITIONS" | "FROM_COMMENTS" | "FROM_FIELDS" | "ALL";
                 showTwin2AttachmentMode?: "HIDE" | "SHORT" | "DETAILED";
+                showTwin2FaceMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2StatusMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2TransitionMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
                 showTwin2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
@@ -32728,6 +32901,7 @@ export interface operations {
                 showPermission2PermissionGroupMode?: "HIDE" | "SHORT" | "DETAILED";
                 showPermissionGroup2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
                 showPermissionMode?: "HIDE" | "SHORT" | "DETAILED";
+                showTwin2FaceMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2StatusMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
                 showTwin2UserMode?: "HIDE" | "SHORT" | "DETAILED";
@@ -32772,6 +32946,49 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["FaceNB001ViewRsV1"];
+                };
+            };
+            /** @description Access is denied */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": Record<string, never>;
+                };
+            };
+        };
+    };
+    faceBC001ViewV1: {
+        parameters: {
+            query: {
+                twinId: string;
+                lazyRelation?: unknown;
+                showFaceMode?: "HIDE" | "SHORT" | "DETAILED";
+            };
+            header: {
+                /** @example f67ad556-dd27-4871-9a00-16fb0e8a4102 */
+                DomainId: string;
+                /** @example 608c6d7d-99c8-4d87-89c6-2f72d0f5d673,9a3f6075-f175-41cd-a804-934201ec969c */
+                AuthToken: string;
+                /** @example WEB */
+                Channel: string;
+            };
+            path: {
+                /** @example 9a3f6075-f175-41cd-a804-934201ec969c */
+                faceId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description BC001 face config */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["FaceTW001ViewRsV1"];
                 };
             };
             /** @description Access is denied */
@@ -33106,6 +33323,7 @@ export interface operations {
                 showStatusMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2AttachmentCollectionMode?: "DIRECT" | "FROM_TRANSITIONS" | "FROM_COMMENTS" | "FROM_FIELDS" | "ALL";
                 showTwin2AttachmentMode?: "HIDE" | "SHORT" | "DETAILED";
+                showTwin2FaceMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2StatusMode?: "HIDE" | "SHORT" | "DETAILED";
                 showTwin2TransitionMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";
                 showTwin2TwinClassMode?: "HIDE" | "SHORT" | "DETAILED" | "MANAGED";

--- a/src/shared/api/generated/schema.d.ts
+++ b/src/shared/api/generated/schema.d.ts
@@ -4339,15 +4339,25 @@ export interface components {
              * @description twin display page pointer
              */
             pageFaceId?: string;
-            /** @description assignee required */
-            assigneeRequired?: boolean;
-            /** @description external id */
-            externalId?: string;
             /**
              * Format: uuid
              * @description breadcrumbs face id
              */
             breadCrumbsFaceId?: string;
+            /**
+             * Format: uuid
+             * @description inherited page face id
+             */
+            inheritedPageFaceId?: string;
+            /**
+             * Format: uuid
+             * @description inherited breadcrumbs face id
+             */
+            inheritedBreadCrumbsFaceId?: string;
+            /** @description assignee required */
+            assigneeRequired?: boolean;
+            /** @description external id */
+            externalId?: string;
         };
         TwinflowBaseV1: {
             /**
@@ -6066,15 +6076,25 @@ export interface components {
              * @description twin display page pointer
              */
             pageFaceId?: string;
-            /** @description assignee required */
-            assigneeRequired?: boolean;
-            /** @description external id */
-            externalId?: string;
             /**
              * Format: uuid
              * @description breadcrumbs face id
              */
             breadCrumbsFaceId?: string;
+            /**
+             * Format: uuid
+             * @description inherited page face id
+             */
+            inheritedPageFaceId?: string;
+            /**
+             * Format: uuid
+             * @description inherited breadcrumbs face id
+             */
+            inheritedBreadCrumbsFaceId?: string;
+            /** @description assignee required */
+            assigneeRequired?: boolean;
+            /** @description external id */
+            externalId?: string;
             /** @description Class fields list */
             fields?: components["schemas"]["TwinClassFieldV1"][];
             /** @description Class fields id list */
@@ -17854,6 +17874,81 @@ export interface components {
             userAreaIcon?: string;
             /** @description menu items list */
             userAreaMenuItems?: components["schemas"]["FaceNB001MenuItemV1"][];
+        };
+        /** @description BC001 item config */
+        FaceBC001ItemV1: {
+            /**
+             * Format: uuid
+             * @description id
+             */
+            id?: string;
+            /**
+             * Format: int32
+             * @description order
+             */
+            order?: number;
+            /**
+             * Format: uuid
+             * @description twin id
+             */
+            twinId?: string;
+            /** @description label */
+            label?: string;
+            /** @description icon url */
+            iconUrl?: string;
+        };
+        /** @description Breadcrumbs widget dto */
+        FaceBC001V1: {
+            /**
+             * Format: uuid
+             * @description config id
+             * @example 9a3f6075-f175-41cd-a804-934201ec969c
+             */
+            id?: string;
+            /**
+             * @description component
+             * @example some domain
+             */
+            component?: string;
+            /** @description name */
+            name?: string;
+            /** @description description */
+            description?: string;
+            /**
+             * Format: date-time
+             * @description created at
+             * @example 2023-09-13T09:32:08
+             */
+            createdAt?: string;
+            /**
+             * Format: uuid
+             * @description createdByUserId
+             */
+            createdByUserId?: string;
+            /** @description items list */
+            items?: components["schemas"]["FaceBC001ItemV1"][];
+        };
+        FaceBC001ViewRsV1: {
+            /**
+             * Format: int32
+             * @description request processing status (see ErrorCode enum)
+             * @example 0
+             */
+            status?: number;
+            /**
+             * @description User friendly, localized request processing status description
+             * @example success
+             */
+            msg?: string;
+            /**
+             * @description request processing status description, technical
+             * @example success
+             */
+            statusDetails?: string;
+            /** @description results - related objects, if lazeRelation is false */
+            relatedObjects?: components["schemas"]["RelatedObjectsV1"];
+            /** @description results - widget details */
+            breadCrumbs?: components["schemas"]["FaceBC001V1"];
         };
         DomainUserViewRsV1: {
             /**
@@ -32988,7 +33083,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["FaceTW001ViewRsV1"];
+                    "application/json": components["schemas"]["FaceBC001ViewRsV1"];
                 };
             };
             /** @description Access is denied */

--- a/src/shared/config/constants.ts
+++ b/src/shared/config/constants.ts
@@ -1,4 +1,5 @@
 export const PlatformArea = {
   workspace: "workspace",
   core: "core",
+  browse: "browse",
 } as const;

--- a/src/widgets/faces/widgets/views/tw001/tw001.tsx
+++ b/src/widgets/faces/widgets/views/tw001/tw001.tsx
@@ -38,7 +38,7 @@ export async function TW001(props: TWidgetFaceProps) {
   if (!twinResult.ok) {
     return <StatusAlert message="Failed to load twin." />;
   }
-  const twin = twinResult.data;
+  const { twin } = twinResult.data;
   const allAttachments = twin.attachments ?? [];
   const relevantAttachments = twidget.imagesTwinClassFieldId
     ? allAttachments.filter(

--- a/src/widgets/faces/widgets/views/tw005/tw005.tsx
+++ b/src/widgets/faces/widgets/views/tw005/tw005.tsx
@@ -39,7 +39,8 @@ export async function TW005(props: TWidgetFaceProps) {
     return <StatusAlert variant="error" message="Failed to load twin." />;
   }
 
-  const { transitionsIdList = [] } = twinResult.data;
+  const { twin } = twinResult.data;
+  const { transitionsIdList = [] } = twin;
 
   return (
     <div data-face-id={id} className={cn("flex gap-2", widget.styleClasses)}>

--- a/src/widgets/faces/widgets/views/wt001/wt001-client.tsx
+++ b/src/widgets/faces/widgets/views/wt001/wt001-client.tsx
@@ -1,6 +1,10 @@
 "use client";
 
+import { usePathname, useRouter } from "next/navigation";
+
 import { FaceTC001ViewRs as FaceTC, FaceWT001 } from "@/entities/face";
+import { Twin_DETAILED } from "@/entities/twin/server";
+import { PlatformArea } from "@/shared/config";
 
 import { TwinsTable } from "../../../../tables";
 
@@ -21,6 +25,26 @@ export function WT001Client<T extends FaceTC = FaceTC>({
   isAdmin,
   modalCreateData,
 }: WT001ClientProps<T>) {
+  const router = useRouter();
+  const pathname = usePathname();
+
+  function handleRowClick(row: Twin_DETAILED) {
+    const segments = pathname.split("/").filter(Boolean);
+    const workspaceIdx = segments.indexOf(PlatformArea.workspace);
+    const basePath = workspaceIdx !== -1 ? segments[workspaceIdx + 1] : "";
+
+    const isOnProductsPage =
+      segments.length === 3 &&
+      segments[0] === PlatformArea.workspace &&
+      basePath === "products";
+
+    if (isOnProductsPage) {
+      router.push(`/${PlatformArea.browse}/${row.id}`);
+    } else {
+      router.push(`/${PlatformArea.workspace}/${basePath}/${row.id}`);
+    }
+  }
+
   return (
     <TwinsTable
       title={title}
@@ -29,6 +53,7 @@ export function WT001Client<T extends FaceTC = FaceTC>({
       showCreateButton={showCreateButton}
       resourceNavigationEnabled={isAdmin}
       modalCreateData={modalCreateData}
+      onRowClick={handleRowClick}
     />
   );
 }

--- a/src/widgets/faces/widgets/views/wt001/wt001-client.tsx
+++ b/src/widgets/faces/widgets/views/wt001/wt001-client.tsx
@@ -33,12 +33,17 @@ export function WT001Client<T extends FaceTC = FaceTC>({
     const workspaceIdx = segments.indexOf(PlatformArea.workspace);
     const basePath = workspaceIdx !== -1 ? segments[workspaceIdx + 1] : "";
 
-    const isOnProductsPage =
+    const isOnCurrentProductPage =
       segments.length === 3 &&
       segments[0] === PlatformArea.workspace &&
       basePath === "products";
 
-    if (isOnProductsPage) {
+    const isBrowsePage =
+      segments.length === 2 && segments[0] === PlatformArea.browse;
+
+    if (isOnCurrentProductPage) {
+      router.push(`/${PlatformArea.browse}/${row.id}`);
+    } else if (isBrowsePage) {
       router.push(`/${PlatformArea.browse}/${row.id}`);
     } else {
       router.push(`/${PlatformArea.workspace}/${basePath}/${row.id}`);

--- a/src/widgets/layout/providers/private.tsx
+++ b/src/widgets/layout/providers/private.tsx
@@ -1,22 +1,31 @@
 import React from "react";
 import { Toaster } from "sonner";
 
+import { FaceBC001Item } from "@/entities/face";
 import { PrivateApiContextProvider } from "@/features/api";
 import { QuickViewProvider } from "@/features/quick-view-overlay";
 import { TooltipProvider } from "@/shared/ui";
 
 import { SidebarLayout } from "../sidebar-layout";
 
+type Props = {
+  children: React.ReactNode;
+  breadcrumbs?: FaceBC001Item[];
+  activeTwinId?: string;
+};
+
 export function PrivateLayoutProviders({
   children,
-}: {
-  children: React.ReactNode;
-}) {
+  breadcrumbs,
+  activeTwinId,
+}: Props) {
   return (
     <PrivateApiContextProvider>
       <QuickViewProvider>
         <TooltipProvider delayDuration={700} skipDelayDuration={0}>
-          <SidebarLayout>{children}</SidebarLayout>
+          <SidebarLayout breadcrumbs={breadcrumbs} activeTwinId={activeTwinId}>
+            {children}
+          </SidebarLayout>
           <Toaster />
         </TooltipProvider>
       </QuickViewProvider>

--- a/src/widgets/layout/sidebar-layout/header.tsx
+++ b/src/widgets/layout/sidebar-layout/header.tsx
@@ -4,9 +4,11 @@ import { House } from "lucide-react";
 import Link from "next/link";
 import React from "react";
 
+import { FaceBC001Item } from "@/entities/face";
+import { BreadCrumbs } from "@/features/ui/bread-crumbs";
 import { ThemeToggle } from "@/features/ui/theme-toggle";
 import { PlatformArea } from "@/shared/config";
-import { cn, useRouteCrumbs } from "@/shared/libs";
+import { cn, isPopulatedArray, isTruthy, useRouteCrumbs } from "@/shared/libs";
 import {
   Breadcrumb,
   BreadcrumbItem,
@@ -15,7 +17,15 @@ import {
 } from "@/shared/ui/breadcrumb";
 import { SidebarTrigger } from "@/shared/ui/sidebar";
 
-export function SidebarLayoutHeader() {
+type SidebarLayoutHeaderProps = {
+  breadcrumbsData?: FaceBC001Item[];
+  activeTwinId?: string;
+};
+
+export function SidebarLayoutHeader({
+  breadcrumbsData,
+  activeTwinId,
+}: SidebarLayoutHeaderProps) {
   const breadcrumbs = useRouteCrumbs();
 
   const displayBreadcrumbs =
@@ -24,37 +34,44 @@ export function SidebarLayoutHeader() {
       ? breadcrumbs.slice(1)
       : breadcrumbs;
 
+  const hasServerBreadcrumbs =
+    isPopulatedArray(breadcrumbsData) && isTruthy(activeTwinId);
+
   return (
     <header className="border-border bg-background sticky top-0 z-10 flex h-16 items-center justify-between border-b px-4 md:px-6">
       <div className="flex items-center">
         <SidebarTrigger className="border-border bg-sidebar z-20 mt-16 mr-4 -ml-4 border shadow-sm md:mr-8 md:-ml-8" />
 
-        <Breadcrumb>
-          <BreadcrumbList>
-            <BreadcrumbItem>
-              <Link href="/">
-                <House className="h-4 w-4" />
-              </Link>
-            </BreadcrumbItem>
-            {displayBreadcrumbs.map((item, index, array) => (
-              <React.Fragment key={index}>
-                <BreadcrumbSeparator />
-                <BreadcrumbItem>
-                  <Link
-                    href={item.href}
-                    title={item.label}
-                    className={cn(
-                      "max-w-28 truncate capitalize",
-                      index === array.length - 1 && "font-semibold"
-                    )}
-                  >
-                    {item.label}
-                  </Link>
-                </BreadcrumbItem>
-              </React.Fragment>
-            ))}
-          </BreadcrumbList>
-        </Breadcrumb>
+        {hasServerBreadcrumbs ? (
+          <BreadCrumbs items={breadcrumbsData} activeTwinId={activeTwinId} />
+        ) : (
+          <Breadcrumb>
+            <BreadcrumbList>
+              <BreadcrumbItem>
+                <Link href="/">
+                  <House className="h-4 w-4" />
+                </Link>
+              </BreadcrumbItem>
+              {displayBreadcrumbs.map((item, index, array) => (
+                <React.Fragment key={index}>
+                  <BreadcrumbSeparator />
+                  <BreadcrumbItem>
+                    <Link
+                      href={item.href}
+                      title={item.label}
+                      className={cn(
+                        "max-w-28 truncate capitalize",
+                        index === array.length - 1 && "font-semibold"
+                      )}
+                    >
+                      {item.label}
+                    </Link>
+                  </BreadcrumbItem>
+                </React.Fragment>
+              ))}
+            </BreadcrumbList>
+          </Breadcrumb>
+        )}
       </div>
 
       <ThemeToggle />

--- a/src/widgets/layout/sidebar-layout/layout.tsx
+++ b/src/widgets/layout/sidebar-layout/layout.tsx
@@ -2,6 +2,7 @@ import { PropsWithChildren } from "react";
 
 import { fetchDomainsList, hydrateDomainView } from "@/entities/domain";
 import {
+  FaceBC001Item,
   FaceNB001,
   FaceNB001MenuItem,
   fetchSidebarFace,
@@ -20,7 +21,10 @@ import { SidebarLayoutContent } from "./content";
 import { SidebarLayoutHeader } from "./header";
 import { AppSidebar } from "./sidebar";
 
-type Props = PropsWithChildren<{}>;
+type SidebarLayoutProps = PropsWithChildren<{
+  breadcrumbs?: FaceBC001Item[];
+  activeTwinId?: string;
+}>;
 
 async function filterAccessibleMenuItems(
   items: FaceNB001MenuItem[],
@@ -46,7 +50,11 @@ async function filterAccessibleMenuItems(
   return result;
 }
 
-export async function SidebarLayout({ children }: Props) {
+export async function SidebarLayout({
+  children,
+  breadcrumbs,
+  activeTwinId,
+}: SidebarLayoutProps) {
   const { currentUserId } = await getAuthHeaders();
   const { domains } = await fetchDomainsList();
   const isAdmin = await isAuthUserGranted({
@@ -87,7 +95,10 @@ export async function SidebarLayout({ children }: Props) {
           domainsList={domains?.map((dto) => hydrateDomainView(dto)) ?? []}
         />
         <div className="w-full">
-          <SidebarLayoutHeader />
+          <SidebarLayoutHeader
+            breadcrumbsData={breadcrumbs}
+            activeTwinId={activeTwinId}
+          />
           <SidebarLayoutContent>{children}</SidebarLayoutContent>
         </div>
       </RenderOnClient>


### PR DESCRIPTION
## Summary

Implement server breadcrumbs to WT001 in products page

## Jira Ticket

- Related ticket: [TWINFACES-617](https://alcosi.atlassian.net/browse/TWINFACES-617)

## Testing

Go to `dev` onSchelves `/workspace/products/`
For testing use this twin
<img width="2243" height="1255" alt="image" src="https://github.com/user-attachments/assets/b43b74e9-789a-4255-9d10-cc9b363eb168" />

