### PR TITLE
[TWINFACES-631] Add loading skeleton for dynamic fields in TC001Form component

### DIFF
--- a/src/widgets/faces/widgets/views/tc001/tc001-form.tsx
+++ b/src/widgets/faces/widgets/views/tc001/tc001-form.tsx
@@ -56,8 +56,6 @@ export function TC001Form({ payload }: { payload: FaceTC001ViewRs }) {
   const [fields, setFields] = useState<TwinClassField[]>([]);
   const didSeed = useRef(false);
 
-  const skeletonCount = loading && fields.length === 0 ? 4 : fields.length;
-
   if (
     !didSeed.current &&
     isSilent &&
@@ -84,6 +82,7 @@ export function TC001Form({ payload }: { payload: FaceTC001ViewRs }) {
           },
           params: selectedOptions[0].twinClassFieldsSearchParams,
         });
+
         setFields(result?.data ?? []);
       } else {
         setFields([]);
@@ -112,35 +111,38 @@ export function TC001Form({ payload }: { payload: FaceTC001ViewRs }) {
         />
       </span>
       <TwinClassSelector />
-      {loading
-        ? [...Array(skeletonCount)].map((_, index) => (
-            <div key={index} className="space-y-2">
-              <Skeleton className="h-5 w-1/3" />
-              <Skeleton className="h-10 w-full" />
-            </div>
-          ))
-        : fields.map((field) => {
-            const selfTwinFieldKey =
-              TWIN_SELF_FIELD_ID_TO_KEY_MAP[field.id as TwinSelfFieldId];
-            const name = (selfTwinFieldKey ??
-              `fields.${field.key}`) as Path<TwinFormValuesByOption>;
 
-            return (
-              <TwinFieldFormField
-                key={field.key}
-                name={name}
-                control={form.control}
-                label={field.name}
-                descriptor={field.descriptor}
-                twinClassId={
-                  isPopulatedArray<{ id: string }>(selectedClass)
-                    ? selectedClass[0]?.id
-                    : ""
-                }
-                required={field.required}
-              />
-            );
-          })}
+      {loading &&
+        Array.from({ length: 4 }, (_, index) => (
+          <div key={index} className="space-y-2">
+            <Skeleton className="h-5 w-1/3" />
+            <Skeleton className="h-10 w-full" />
+          </div>
+        ))}
+
+      {!loading &&
+        fields.map((field) => {
+          const selfTwinFieldKey =
+            TWIN_SELF_FIELD_ID_TO_KEY_MAP[field.id as TwinSelfFieldId];
+          const name = (selfTwinFieldKey ??
+            `fields.${field.key}`) as Path<TwinFormValuesByOption>;
+
+          return (
+            <TwinFieldFormField
+              key={field.key}
+              name={name}
+              control={form.control}
+              label={field.name}
+              descriptor={field.descriptor}
+              twinClassId={
+                isPopulatedArray<{ id: string }>(selectedClass)
+                  ? selectedClass[0]?.id
+                  : ""
+              }
+              required={field.required}
+            />
+          );
+        })}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Added display of skeleton when receiving fields.
Fixed a bug with changing the option (fields and the selected class in the combo box were not cleared)

## Jira Ticket

- Related ticket: [TWINFACES-631](https://alcosi.atlassian.net/browse/TWINFACES-631)

## Description

When selecting another option, fields and classes belonging to the previous option were displayed, and also, with silent mode, requests to the API did not occur

## Testing

env: DEV/TEST
TC001 form in products and marketplaces pages



[TWINFACES-631]: https://alcosi.atlassian.net/browse/TWINFACES-631?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ