### PR TITLE
[TWINFACES-634] fix Widget TW001 and TW004

### DIFF
--- a/src/entities/face/api/actions/widget-twidget.ts
+++ b/src/entities/face/api/actions/widget-twidget.ts
@@ -110,7 +110,7 @@ export async function fetchTW001Face(
     twinId,
     faceId,
     query: {
-      showFaceTW0012TwinClassFieldMode: "MANAGED",
+      showFaceTW0012TwinClassFieldMode: "DETAILED",
       showFaceTwidget2TwinMode: "DETAILED",
       showAttachment2TwinMode: "DETAILED",
       showTwin2AttachmentCollectionMode: "ALL",

--- a/src/features/twin/ui/field-editor/field-editor.tsx
+++ b/src/features/twin/ui/field-editor/field-editor.tsx
@@ -73,6 +73,7 @@ export function TwinFieldEditor({
       <InheritedFieldPreview
         field={field}
         disabled={disabled}
+        editable={editable}
         onChange={handleOnSubmit}
       />
     );

--- a/src/features/twin/ui/field-editor/inherited-field-preview.tsx
+++ b/src/features/twin/ui/field-editor/inherited-field-preview.tsx
@@ -25,12 +25,14 @@ import { UserResourceLink } from "../../../../features/user/ui";
 type Props = {
   field: TwinFieldUI;
   disabled?: boolean;
+  editable?: boolean;
   onChange?: (value: string) => void;
 };
 
 export function InheritedFieldPreview({
   field,
   disabled = false,
+  editable = true,
   onChange,
 }: Props) {
   const { descriptor, value } = field;
@@ -143,7 +145,7 @@ export function InheritedFieldPreview({
           <SwitchFormItem
             fieldValue={checked}
             onChange={(v) => onChange?.(String(v))}
-            disabled={disabled}
+            disabled={!editable}
           />
         );
       }
@@ -152,7 +154,7 @@ export function InheritedFieldPreview({
         <CheckboxFormItem
           fieldValue={checked}
           onChange={(v) => onChange?.(String(v))}
-          disabled={disabled}
+          disabled={!editable}
         />
       );
     }


### PR DESCRIPTION
## Summary

Widget TW001 breaks and TW004 becomes disabled for non-admin users

## Jira Ticket

- Related ticket: https://alcosi.atlassian.net/browse/TWINFACES-634


## Description

When logging in as a non-admin user and navigating to the Product detail page, two issues occur:

TW001 widget breaks due to incorrect show
TW004 widget (for booleanV1 fields) renders a disabled checkbox,

## Testing

.env: TEST

**Steps**

1) log in as non-admin user 
**User**: vasili.zasinets@gmail.com
**Password**: helloworld
2) enter the product