### PR TITLE
[TWINFACES-637] Replace twinClassKeyLikeList with nameI18nLikeList in useTwinClassBySearchIdSelectAdapter

### DIFF
--- a/src/entities/twin-class/libs/hooks/use-select-adapter.ts
+++ b/src/entities/twin-class/libs/hooks/use-select-adapter.ts
@@ -75,7 +75,7 @@ export function useTwinClassBySearchIdSelectAdapter(): SelectAdapter<TwinClass_D
     const response = await searchBySearchId({
       searchId,
       narrow: {
-        twinClassKeyLikeList: [wrapWithPercent(search)],
+        nameI18nLikeList: [wrapWithPercent(search)],
       },
       params,
     });


### PR DESCRIPTION
## Summary

Replace twinClassKeyLikeList with nameI18nLikeList in useTwinClassBySearchIdSelectAdapter

## Jira Ticket

- Related ticket: [TWINFACES-637](https://alcosi.atlassian.net/browse/TWINFACES-637)

## Description

Replace twinClassKeyLikeList with nameI18nLikeList in useTwinClassBySearchIdSelectAdapter

## Testing

.env: TEST

Open twin create modal (TC001 component) select class combobox, use search class
result:
<img width="2089" height="935" alt="image" src="https://github.com/user-attachments/assets/bad78198-2073-4027-9aab-7790290ce7cc" />




[TWINFACES-637]: https://alcosi.atlassian.net/browse/TWINFACES-637?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ