### PR TITLE
[TWINFACES-632] added button for adding images

### DIFF
--- a/src/entities/twin/server/api/api-service.ts
+++ b/src/entities/twin/server/api/api-service.ts
@@ -42,17 +42,13 @@ export async function fetchTwinById<T extends Twin_HYDRATED>(
   return data.twin as T;
 }
 
-export async function uploadTwinAttachment({
-  twinId,
-  file,
-  options,
-}: {
-  twinId: string;
-  file: File;
+export async function uploadTwinAttachment(
+  twinId: string,
+  file: File,
   options: {
     imagesTwinClassFieldId?: string;
-  };
-}) {
+  }
+) {
   const header = await getAuthHeaders();
 
   const formData = new FormData();

--- a/src/entities/twin/server/api/api-service.ts
+++ b/src/entities/twin/server/api/api-service.ts
@@ -42,7 +42,15 @@ export async function fetchTwinById<T extends Twin_HYDRATED>(
   return data.twin as T;
 }
 
-export async function uploadTwinAttachment(twinId: string, file: File) {
+export async function uploadTwinAttachment({
+  twinId,
+  imagesTwinClassFieldId,
+  file,
+}: {
+  twinId: string;
+  imagesTwinClassFieldId: string;
+  file: File;
+}) {
   const header = await getAuthHeaders();
 
   const formData = new FormData();
@@ -57,6 +65,7 @@ export async function uploadTwinAttachment(twinId: string, file: File) {
         title: file.name,
         size: file.size,
         description: "User uploaded image",
+        twinClassFieldId: imagesTwinClassFieldId,
       },
     ],
   };

--- a/src/entities/twin/server/api/api-service.ts
+++ b/src/entities/twin/server/api/api-service.ts
@@ -44,12 +44,14 @@ export async function fetchTwinById<T extends Twin_HYDRATED>(
 
 export async function uploadTwinAttachment({
   twinId,
-  imagesTwinClassFieldId,
   file,
+  options,
 }: {
   twinId: string;
-  imagesTwinClassFieldId: string;
   file: File;
+  options: {
+    imagesTwinClassFieldId?: string;
+  };
 }) {
   const header = await getAuthHeaders();
 
@@ -60,12 +62,11 @@ export async function uploadTwinAttachment({
   const payload = {
     attachments: [
       {
-        twinId,
         storageLink: "multipart://file",
         title: file.name,
         size: file.size,
         description: "User uploaded image",
-        twinClassFieldId: imagesTwinClassFieldId,
+        twinClassFieldId: options.imagesTwinClassFieldId,
       },
     ],
   };

--- a/src/features/ui/sliders/media-carousel/media-carousel-placeholder.tsx
+++ b/src/features/ui/sliders/media-carousel/media-carousel-placeholder.tsx
@@ -1,13 +1,31 @@
+import { UploadCloudIcon } from "lucide-react";
+
 import { NoImageIcon } from "@/shared/ui";
 
-export function MediaCarouselPlaceholder() {
+import { FileUploadButton } from "../../file-upload-button";
+
+type Props = {
+  onUploadFile: (file: File) => Promise<void>;
+};
+
+export function MediaCarouselPlaceholder({ onUploadFile }: Props) {
   return (
     <>
       <div className="border-border text-muted-foreground mb-2 flex min-h-96 w-full flex-col items-center justify-center rounded-md border border-dashed p-4">
         <div className="mb-2 text-4xl">
           <NoImageIcon className="h-14 w-14" />
         </div>
-        <p className="text-sm">No media found</p>
+        <p className="text-sm">No media found. Upload images to display.</p>
+
+        <FileUploadButton
+          title="Upload File"
+          variant="outline"
+          onChange={onUploadFile}
+          className="mt-3"
+        >
+          <UploadCloudIcon className="mr-2 h-5 w-5" />
+          add file
+        </FileUploadButton>
       </div>
       <div className="text-muted-foreground mt-2 flex w-full items-center justify-between gap-4">
         <div className="border-border flex h-10 w-10 items-center justify-center rounded-full border border-dashed text-center" />

--- a/src/features/ui/sliders/media-carousel/media-carousel-placeholder.tsx
+++ b/src/features/ui/sliders/media-carousel/media-carousel-placeholder.tsx
@@ -24,7 +24,7 @@ export function MediaCarouselPlaceholder({ onUploadFile }: Props) {
           className="mt-3"
         >
           <UploadCloudIcon className="mr-2 h-5 w-5" />
-          add file
+          Upload attachment
         </FileUploadButton>
       </div>
       <div className="text-muted-foreground mt-2 flex w-full items-center justify-between gap-4">

--- a/src/features/ui/sliders/media-carousel/media-carousel.tsx
+++ b/src/features/ui/sliders/media-carousel/media-carousel.tsx
@@ -62,7 +62,7 @@ export function MediaCarousel<T extends Media>({
   }, [mainSlider]);
 
   if (isEmptyArray(items)) {
-    return <MediaCarouselPlaceholder />;
+    return <MediaCarouselPlaceholder onUploadFile={onUploadFile} />;
   }
 
   return (

--- a/src/widgets/faces/widgets/views/tw001/tw001-client.tsx
+++ b/src/widgets/faces/widgets/views/tw001/tw001-client.tsx
@@ -8,13 +8,18 @@ import { Media, MediaCarousel } from "@/features/ui/sliders";
 type TW001ClientProps = {
   items: Media[];
   twinId: string;
+  imagesTwinClassFieldId: string;
 };
 
-export function TW001Client({ items, twinId }: TW001ClientProps) {
+export function TW001Client({
+  items,
+  twinId,
+  imagesTwinClassFieldId,
+}: TW001ClientProps) {
   const router = useRouter();
 
   async function handleUploadFile(file: File) {
-    await uploadTwinAttachment(twinId, file);
+    await uploadTwinAttachment({ twinId, imagesTwinClassFieldId, file });
     router.refresh();
   }
 

--- a/src/widgets/faces/widgets/views/tw001/tw001-client.tsx
+++ b/src/widgets/faces/widgets/views/tw001/tw001-client.tsx
@@ -17,7 +17,7 @@ export function TW001Client({ items, twinId, options }: TW001ClientProps) {
   const router = useRouter();
 
   async function handleUploadFile(file: File) {
-    await uploadTwinAttachment({ twinId, options, file });
+    await uploadTwinAttachment(twinId, file, options);
     router.refresh();
   }
 

--- a/src/widgets/faces/widgets/views/tw001/tw001-client.tsx
+++ b/src/widgets/faces/widgets/views/tw001/tw001-client.tsx
@@ -8,18 +8,16 @@ import { Media, MediaCarousel } from "@/features/ui/sliders";
 type TW001ClientProps = {
   items: Media[];
   twinId: string;
-  imagesTwinClassFieldId: string;
+  options: {
+    imagesTwinClassFieldId?: string;
+  };
 };
 
-export function TW001Client({
-  items,
-  twinId,
-  imagesTwinClassFieldId,
-}: TW001ClientProps) {
+export function TW001Client({ items, twinId, options }: TW001ClientProps) {
   const router = useRouter();
 
   async function handleUploadFile(file: File) {
-    await uploadTwinAttachment({ twinId, imagesTwinClassFieldId, file });
+    await uploadTwinAttachment({ twinId, options, file });
     router.refresh();
   }
 

--- a/src/widgets/faces/widgets/views/tw001/tw001.tsx
+++ b/src/widgets/faces/widgets/views/tw001/tw001.tsx
@@ -65,7 +65,11 @@ export async function TW001(props: TWidgetFaceProps) {
       className={cn("h-auto w-full max-w-[480px] object-contain", className)}
     >
       {twidget.label && <p>{twidget.label}</p>}
-      <TW001Client items={typedMedia} twinId={twinId} />
+      <TW001Client
+        items={typedMedia}
+        twinId={twidget.pointedTwinId!}
+        imagesTwinClassFieldId={twidget.imagesTwinClassFieldId!}
+      />
     </div>
   );
 }

--- a/src/widgets/faces/widgets/views/tw001/tw001.tsx
+++ b/src/widgets/faces/widgets/views/tw001/tw001.tsx
@@ -68,7 +68,7 @@ export async function TW001(props: TWidgetFaceProps) {
       <TW001Client
         items={typedMedia}
         twinId={twidget.pointedTwinId!}
-        imagesTwinClassFieldId={twidget.imagesTwinClassFieldId!}
+        options={{ imagesTwinClassFieldId: twidget.imagesTwinClassFieldId }}
       />
     </div>
   );


### PR DESCRIPTION
## Summary

upload pictures TW001

## Jira Ticket

- Related ticket: [[TWINFACES-632](https://alcosi.atlassian.net/browse/TWINFACES-632)]

## Description

- added a button to upload files to MediaCarouselPlaceholder if there are no media elements.

- in the tw001.tsx file you need to pass twinId={twidget.pointedTwinId!}:
`what is this for??, if you go to the table by the arrow in the screenshot, then when adding a picture you need to send pointedTwinId`
```
<TW001Client
    items={typedMedia}
    twinId={twidget.pointedTwinId!}
    imagesTwinClassFieldId={twidget.imagesTwinClassFieldId!}
 />
```
## Testing
dev-twins-onshelves
Open product e.g (browse/1ce116d9-0ef5-42c6-9233-ab26e64b0e35)
<img width="1128" height="783" alt="Снимок экрана 2025-08-13 в 10 49 45" src="https://github.com/user-attachments/assets/dbce6cc6-2c02-4f10-a073-2c675e3ac577" />



[TWINFACES-632]: https://alcosi.atlassian.net/browse/TWINFACES-632?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ