### PR TITLE
[TWINFACES-639] Fix incorrect widget ordering in Masonry layout due to row-start-N handling bug

### DIFF
--- a/src/features/ui/masonry.tsx
+++ b/src/features/ui/masonry.tsx
@@ -54,7 +54,7 @@ export function MasonryLayout({
     const itemNode = (
       <Masonry.Item
         key={index}
-        className="relative" //NOTE use `debug` class to enable debug mode
+        className="relative"
         col={distributedColIndex + 1}
         row={isFinite(rowIndex) ? rowIndex + 1 : undefined}
       >

--- a/src/shared/ui/masonry.tsx
+++ b/src/shared/ui/masonry.tsx
@@ -11,7 +11,7 @@ export function Grid({
   className?: string | string[];
 }>) {
   return (
-    <div className={cn(`group columns-${colCount}`, className)}>{children}</div> //NOTE use `debug` class to enable debug mode
+    <div className={cn(`group columns-${colCount}`, className)}>{children}</div>
   );
 }
 
@@ -26,20 +26,24 @@ function Column({
   );
 }
 
-function Item({
-  className,
-  children,
-  col,
-  row,
-}: PropsWithChildren<{
-  className?: string | string[];
-  col?: number;
-  row?: number;
-}>) {
+function Item(
+  props: PropsWithChildren<{
+    testId?: string;
+    className?: string | string[];
+  }>
+) {
+  const { testId, className, children } = props;
+
   return (
-    <div className={cn("min-w-0 break-inside-avoid", className)}>
-      <span className="pointer-events-none absolute top-0 left-0 z-10 hidden rounded-br bg-red-600 px-2 py-0.5 text-xs font-bold text-white group-[.debug]:inline-flex">
-        {col != null && row != null ? `col-${col}(row-${row})` : ""}
+    <div
+      className={cn(
+        "relative min-w-0 break-inside-avoid",
+        "group-[.debug]:border-error group-[.debug]:border-2 group-[.debug]:border-dashed",
+        className
+      )}
+    >
+      <span className="bg-error text-secondary pointer-events-none absolute top-0 left-0 z-10 hidden rounded-br px-2 py-0.5 text-xs font-bold group-[.debug]:inline">
+        {testId ?? "N/A"}
       </span>
       {children}
     </div>

--- a/src/shared/ui/masonry.tsx
+++ b/src/shared/ui/masonry.tsx
@@ -10,7 +10,9 @@ export function Grid({
   colCount: number;
   className?: string | string[];
 }>) {
-  return <div className={cn(`columns-${colCount}`, className)}>{children}</div>;
+  return (
+    <div className={cn(`group columns-${colCount}`, className)}>{children}</div> //NOTE use `debug` class to enable debug mode
+  );
 }
 
 function Column({
@@ -34,18 +36,11 @@ function Item({
   col?: number;
   row?: number;
 }>) {
-  const classes = Array.isArray(className)
-    ? className.join(" ")
-    : (className ?? "");
-  const isDebug = classes.includes("debug");
-
   return (
-    <div className={cn("min-w-0 break-inside-avoid", classes)}>
-      {isDebug && col != null && row != null && (
-        <span className="absolute top-0 left-0 z-10 rounded-br bg-red-600 px-2 py-0.5 text-xs font-bold text-white">
-          col-{col}(row-{row})
-        </span>
-      )}
+    <div className={cn("min-w-0 break-inside-avoid", className)}>
+      <span className="pointer-events-none absolute top-0 left-0 z-10 hidden rounded-br bg-red-600 px-2 py-0.5 text-xs font-bold text-white group-[.debug]:inline-flex">
+        {col != null && row != null ? `col-${col}(row-${row})` : ""}
+      </span>
       {children}
     </div>
   );

--- a/src/shared/ui/masonry.tsx
+++ b/src/shared/ui/masonry.tsx
@@ -27,9 +27,25 @@ function Column({
 function Item({
   className,
   children,
-}: PropsWithChildren<{ className?: string | string[] }>) {
+  col,
+  row,
+}: PropsWithChildren<{
+  className?: string | string[];
+  col?: number;
+  row?: number;
+}>) {
+  const classes = Array.isArray(className)
+    ? className.join(" ")
+    : (className ?? "");
+  const isDebug = classes.includes("debug");
+
   return (
-    <div className={cn("min-w-0 break-inside-avoid", className)}>
+    <div className={cn("min-w-0 break-inside-avoid", classes)}>
+      {isDebug && col != null && row != null && (
+        <span className="absolute top-0 left-0 z-10 rounded-br bg-red-600 px-2 py-0.5 text-xs font-bold text-white">
+          col-{col}(row-{row})
+        </span>
+      )}
       {children}
     </div>
   );


### PR DESCRIPTION
## Summary

Fix incorrect widget ordering in Masonry layout due to row-start-N handling bug

## Jira Ticket

- Related ticket: [TWINFACES-639](https://alcosi.atlassian.net/browse/TWINFACES-639)

## Description

Fixed the order of displaying widgets on the product page.
Also added a debug mode to check the correct order of rendering widgets (enabled by adding the debug class to the parent wrapper)

<img width="1789" height="1046" alt="image" src="https://github.com/user-attachments/assets/75a0a883-d2aa-4502-8251-6e5724624723" />


## Testing

.end - DEV
go to the detailed product page and enabled debug mode to check correct order


[TWINFACES-639]: https://alcosi.atlassian.net/browse/TWINFACES-639?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ