### PR TITLE
[SHLVS-892] Replace optionLikeList filter with optionI18nLikeList in /public/data_list_option/search/v1 endpoint

### DIFF
--- a/src/entities/datalist-option/api/types.ts
+++ b/src/entities/datalist-option/api/types.ts
@@ -10,8 +10,8 @@ export type DataListOptionUpdateRqV1 =
 export type DataListOptionFilterKeys =
   | "idList"
   | "dataListIdList"
-  | "optionLikeList"
-  | "statusIdList";
+  | "statusIdList"
+  | "optionI18nLikeList";
 
 export type DataListOptionFilters = Partial<
   Pick<

--- a/src/entities/datalist-option/libs/hooks/use-filters.ts
+++ b/src/entities/datalist-option/libs/hooks/use-filters.ts
@@ -40,7 +40,7 @@ export function useDatalistOptionFilters({
       ...dAdapter,
     },
 
-    optionLikeList: {
+    optionI18nLikeList: {
       type: AutoFormValueType.tag,
       label: "Name",
     },
@@ -68,7 +68,7 @@ export function useDatalistOptionFilters({
     const result: DataListOptionFilters = {
       idList: toArrayOfString(toArray(filters.idList), "id"),
       dataListIdList: toArrayOfString(toArray(filters.dataListIdList), "id"),
-      optionLikeList: toArrayOfString(filters.optionLikeList).map(
+      optionI18nLikeList: toArrayOfString(filters.optionI18nLikeList).map(
         wrapWithPercent
       ),
       statusIdList: toArray(

--- a/src/entities/datalist-option/libs/hooks/use-select-adapter.ts
+++ b/src/entities/datalist-option/libs/hooks/use-select-adapter.ts
@@ -1,8 +1,9 @@
 import {
-  isPopulatedString,
   SelectAdapter,
+  isPopulatedString,
   wrapWithPercent,
 } from "@/shared/libs";
+
 import {
   DataListOptionFilters,
   DataListOptionV3,
@@ -24,9 +25,9 @@ export function useDatalistOptionSelectAdapter(): SelectAdapter<DataListOptionV3
   async function getItems(search: string, filters?: DataListOptionFilters) {
     const response = await searchDatalistOptions({
       filters: {
-        optionLikeList: isPopulatedString(search)
+        optionI18nLikeList: isPopulatedString(search)
           ? [wrapWithPercent(search)]
-          : filters?.optionLikeList,
+          : filters?.optionI18nLikeList,
         ...filters,
       },
     });

--- a/src/widgets/tables/datalist-options/datalist-options.tsx
+++ b/src/widgets/tables/datalist-options/datalist-options.tsx
@@ -44,7 +44,7 @@ export function DatalistOptionsTable({ datalist }: { datalist?: DataList }) {
   const { createDatalistOption } = useCreateDatalistOption();
   const { buildFilterFields, mapFiltersToPayload } = useDatalistOptionFilters({
     enabledFilters: isTruthy(datalist?.id)
-      ? ["idList", "optionLikeList", "statusIdList"]
+      ? ["idList", "optionI18nLikeList", "statusIdList"]
       : undefined,
   });
   const [columns, setColumns] = useState<ColumnDef<DataListOptionV3>[]>([]);


### PR DESCRIPTION
## Summary

Replace `optionLikeList` filter with `optionI18nLikeList` in `/public/data_list_option/search/v1` endpoint

## Jira Ticket

- Related ticket: [SHLVS-892](https://alcosi.atlassian.net/browse/SHLVS-892)

## Description

Replace `optionLikeList` filter with `optionI18nLikeList` in `/public/data_list_option/search/v1` endpoint

## Testing

.end - DEV

1) Go to detailed product page
2) Open modal create in this table
<img width="485" height="144" alt="image" src="https://github.com/user-attachments/assets/984c704d-5436-487c-88ac-7d1e2dac88d4" />

3) Select locale
<img width="496" height="648" alt="image" src="https://github.com/user-attachments/assets/59da01e6-81a6-4c5b-9ce2-dd953be39ec3" />

4) Open devtools and you can see filter
<img width="420" height="95" alt="image" src="https://github.com/user-attachments/assets/bc59485b-2cfc-467d-bbd1-62f31499c273" />




[SHLVS-892]: https://alcosi.atlassian.net/browse/SHLVS-892?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ