### PR TITLE
[TWINFACES-579] Implement Refresh Token Middleware in Fetch Client

### DIFF
--- a/src/entities/user/server/actions/auth.ts
+++ b/src/entities/user/server/actions/auth.ts
@@ -18,6 +18,7 @@ import {
 import {
   AuthConfig,
   AuthLoginRs,
+  AuthRefreshRs,
   AuthSignUpVerificationByEmailRs,
   AuthSignupByEmailRs,
 } from "../types";
@@ -258,5 +259,36 @@ export async function requirePermissionsOr404(permissionIds: string[]) {
     if (!allowed) {
       notFound();
     }
+  }
+}
+
+export async function refreshAuthTokenAction(
+  authToken: string,
+  refreshToken: string,
+  domainId: string
+): Promise<Result<AuthRefreshRs>> {
+  try {
+    const { data, error } = await TwinsAPI.POST("/auth/refresh/v2", {
+      params: {
+        header: {
+          AuthToken: authToken,
+          DomainId: domainId,
+          Channel: "WEB",
+        },
+      },
+      body: { refreshToken },
+    });
+
+    if (error) {
+      return errorToResult(error);
+    }
+
+    if (isUndefined(data)) {
+      return errorToResult(error);
+    }
+
+    return { ok: true, data };
+  } catch (error) {
+    return errorToResult(error);
   }
 }

--- a/src/entities/user/server/types/auth.ts
+++ b/src/entities/user/server/types/auth.ts
@@ -8,3 +8,4 @@ export type AuthSignupByEmailRs =
   components["schemas"]["AuthSignupByEmailRsV1"];
 export type AuthSignUpVerificationByEmailRs =
   components["schemas"]["AuthSignupByEmailConfirmRsV1"];
+export type AuthRefreshRs = components["schemas"]["AuthRefreshRsV1"];

--- a/src/features/auth/useAuthUser.tsx
+++ b/src/features/auth/useAuthUser.tsx
@@ -9,6 +9,8 @@ type AuthUser = {
   domainUser?: DomainUser_DETAILED;
   authToken: string;
   domainId: string;
+  refreshToken?: string;
+  authTokenExpiresAt?: string;
 };
 
 type UseAuthUser = {
@@ -35,6 +37,10 @@ export function useAuthUser(): UseAuthUser {
       clientCookies.set("authToken", `${user?.authToken}`, { path: "/" });
       clientCookies.set("domainId", `${user?.domainId}`, { path: "/" });
       clientCookies.set("userId", `${user?.domainUser?.userId}`, { path: "/" });
+      clientCookies.set("refreshToken", `${user?.refreshToken}`, { path: "/" });
+      clientCookies.set("authTokenExpiresAt", `${user?.authTokenExpiresAt}`, {
+        path: "/",
+      });
     },
     [setStoredValue]
   );
@@ -54,6 +60,8 @@ export function useAuthUser(): UseAuthUser {
     clientCookies.remove("authToken");
     clientCookies.remove("domainId");
     clientCookies.remove("userId");
+    clientCookies.remove("refreshToken");
+    clientCookies.remove("authTokenExpiresAt");
   }, [setStoredValue]);
 
   return {

--- a/src/shared/api/client/client.ts
+++ b/src/shared/api/client/client.ts
@@ -4,6 +4,7 @@ import createClient from "openapi-fetch";
 import { paths } from "@/shared/api/generated/schema";
 
 import { errorMiddleware } from "./middleware/error";
+import { refreshTokenMiddleware } from "./middleware/refresh-token";
 import { unauthorizedMiddleware } from "./middleware/unauthorized";
 
 export const EXPIRED_SESSION_TAG = "session_expired";
@@ -15,3 +16,5 @@ export const TwinsAPI = createClient<paths>({
 // NOTE: order matters: normalize errors first, then handle 401s
 TwinsAPI.use(errorMiddleware);
 TwinsAPI.use(unauthorizedMiddleware);
+// NOTE: If auth token expires in <= treshholdMinutes, it will be refreshed before the request
+TwinsAPI.use(refreshTokenMiddleware(1));

--- a/src/shared/api/client/middleware/refresh-token.ts
+++ b/src/shared/api/client/middleware/refresh-token.ts
@@ -1,0 +1,82 @@
+import { Middleware } from "openapi-fetch";
+
+import { isServerRuntime } from "@/shared/libs";
+
+import { refreshAuthTokenAction } from "../../../../entities/user/server";
+
+type RefreshData = {
+  auth_token: string;
+  refresh_token: string;
+  auth_token_expires_at: string;
+};
+
+function getClientCookie(name: string): string | undefined {
+  return document.cookie
+    .split("; ")
+    .find((row) => row.startsWith(`${name}=`))
+    ?.split("=")[1];
+}
+
+const IGNORED_PATHS = ["/auth/refresh/v2"];
+
+export function refreshTokenMiddleware(treshholdMinutes = 10): Middleware {
+  let refreshingPromise: Promise<void> | null = null;
+
+  return {
+    async onRequest({ request }) {
+      const url = new URL(request.url);
+      if (IGNORED_PATHS.includes(url.pathname)) return request;
+
+      if (isServerRuntime()) return request;
+
+      let authToken = getClientCookie("authToken");
+      const refreshToken = getClientCookie("refreshToken");
+      const authTokenExpiresAt = getClientCookie("authTokenExpiresAt");
+      const domainId = getClientCookie("domainId");
+
+      if (authToken && refreshToken && authTokenExpiresAt && domainId) {
+        try {
+          const expiresAt = new Date(decodeURIComponent(authTokenExpiresAt));
+          const diffMinutes =
+            (expiresAt.getTime() - new Date().getTime()) / 1000 / 60;
+
+          if (diffMinutes <= treshholdMinutes) {
+            if (!refreshingPromise) {
+              refreshingPromise = (async () => {
+                const result = await refreshAuthTokenAction(
+                  authToken!,
+                  refreshToken!,
+                  domainId!
+                );
+
+                if (result.ok) {
+                  const {
+                    auth_token: newAuthToken,
+                    refresh_token: newRefreshToken,
+                    auth_token_expires_at: newAuthTokenExpiresAt,
+                  } = result.data.authData as RefreshData;
+
+                  document.cookie = `authToken=${newAuthToken}; path=/`;
+                  document.cookie = `refreshToken=${newRefreshToken}; path=/`;
+                  document.cookie = `authTokenExpiresAt=${newAuthTokenExpiresAt}; path=/`;
+                }
+              })().finally(() => {
+                refreshingPromise = null;
+              });
+            }
+
+            await refreshingPromise;
+            authToken = getClientCookie("authToken");
+          }
+        } catch (error) {
+          console.error("refreshTokenMiddleware error", error);
+        }
+      }
+
+      if (authToken) request.headers.set("AuthToken", authToken);
+      if (domainId) request.headers.set("DomainId", domainId);
+
+      return request;
+    },
+  };
+}

--- a/src/widgets/auth/forms/email-password-sign-in.tsx
+++ b/src/widgets/auth/forms/email-password-sign-in.tsx
@@ -50,7 +50,6 @@ export function EmailPasswordSignInForm({
   function onSignInSubmit(
     values: z.infer<typeof EMAIL_PASSWORD_SIGN_IN_SCHEMA>
   ) {
-    // setAuthError(null);
     signInForm.setError("root", {});
 
     const domainId = values.domainId;
@@ -76,6 +75,8 @@ export function EmailPasswordSignInForm({
 
       if (result.ok) {
         const authToken = result.data.authData?.auth_token;
+        const refreshToken = result.data.authData?.refresh_token;
+        const authTokenExpiresAt = result.data.authData?.auth_token_expires_at;
         if (isUndefined(authToken)) {
           return handleAuthError("Login failed: no auth token returned");
         }
@@ -93,6 +94,8 @@ export function EmailPasswordSignInForm({
           domainUser,
           authToken,
           domainId,
+          refreshToken,
+          authTokenExpiresAt,
         });
 
         router.push(`/profile`);

--- a/src/widgets/auth/methods/email-password.tsx
+++ b/src/widgets/auth/methods/email-password.tsx
@@ -58,6 +58,8 @@ export function EmailPasswordAuthWidget() {
 
     if (result.ok) {
       const authToken = result.data.authData?.auth_token;
+      const refreshToken = result.data.authData?.refresh_token;
+      const authTokenExpiresAt = result.data.authData?.auth_token_expires_at;
       if (isUndefined(authToken)) {
         throw new Error("Login failed: no auth token returned");
       }
@@ -75,6 +77,8 @@ export function EmailPasswordAuthWidget() {
         domainUser: domainUser,
         authToken: authToken,
         domainId,
+        refreshToken,
+        authTokenExpiresAt,
       });
 
       router.push("/profile");


### PR DESCRIPTION
## Summary

Implement Refresh Token Middleware

## Jira Ticket

- Related ticket: [TWINFACES-579](https://alcosi.atlassian.net/browse/TWINFACES-579)

## Description

Implemented refresh token functionality based on a threshold, which checks the authToken's expiration before sending each request and refreshes it if it’s about to expire.

## Testing

.env - TEST
Token expiration time - 11m

