### PR TITLE
[TWINFACES-946] Implement [page] twin trigger [tab] usages

### DIFF
--- a/src/entities/twin-trigger/libs/hooks/use-select-adapter.ts
+++ b/src/entities/twin-trigger/libs/hooks/use-select-adapter.ts
@@ -1,4 +1,8 @@
-import { SelectAdapter, isPopulatedString } from "@/shared/libs";
+import {
+  SelectAdapter,
+  isPopulatedString,
+  wrapWithPercent,
+} from "@/shared/libs";
 
 import { useTwinTriggerSearch } from "../../api/hooks";
 import { TwinTrigger_DETAILED } from "../../api/types";
@@ -16,8 +20,13 @@ export function useTwinTriggerSelectAdapter(): SelectAdapter<TwinTrigger_DETAILE
 
   async function getItems(search: string) {
     const response = await searchTwinTriggers({
-      pagination: { pageIndex: 0, pageSize: 20 },
-      filters: { nameLikeList: search ? [search] : undefined },
+      pagination: {
+        pageIndex: 0,
+        pageSize: 10,
+      },
+      filters: {
+        nameLikeList: search ? [wrapWithPercent(search)] : undefined,
+      },
     });
     return response.data;
   }

--- a/src/screens/twin-trigger/twin-trigger.tsx
+++ b/src/screens/twin-trigger/twin-trigger.tsx
@@ -2,13 +2,18 @@
 
 import { Tab, TabsLayout } from "@/widgets/layout";
 
-import { TwinTriggerGeneral } from "./views";
+import { TwinTriggerGeneral, TwinTriggerUsages } from "./views";
 
 const tabs: Tab[] = [
   {
     key: "general",
     label: "General",
     content: <TwinTriggerGeneral />,
+  },
+  {
+    key: "usages",
+    label: "Usages",
+    content: <TwinTriggerUsages />,
   },
 ];
 

--- a/src/screens/twin-trigger/views/index.ts
+++ b/src/screens/twin-trigger/views/index.ts
@@ -1,1 +1,2 @@
 export * from "./twin-trigger-general";
+export * from "./twin-trigger-usages";

--- a/src/screens/twin-trigger/views/twin-trigger-usages.tsx
+++ b/src/screens/twin-trigger/views/twin-trigger-usages.tsx
@@ -1,0 +1,19 @@
+import { useContext } from "react";
+
+import { TwinTriggerContext } from "@/features/twin-trigger";
+import { FactoryTriggersTable, StatusTriggersTable } from "@/widgets/tables";
+import { TransitionTriggersTable } from "@/widgets/tables/transition-triggers";
+
+export function TwinTriggerUsages() {
+  const { twinTriggerId } = useContext(TwinTriggerContext);
+
+  return (
+    <>
+      <StatusTriggersTable twinTriggerId={twinTriggerId} />
+
+      <FactoryTriggersTable twinTriggerId={twinTriggerId} />
+
+      <TransitionTriggersTable twinTriggerId={twinTriggerId} />
+    </>
+  );
+}

--- a/src/widgets/tables/factory-triggers/factory-triggers.tsx
+++ b/src/widgets/tables/factory-triggers/factory-triggers.tsx
@@ -1,6 +1,7 @@
 import { zodResolver } from "@hookform/resolvers/zod";
 import { ColumnDef, PaginationState } from "@tanstack/react-table";
 import { Check } from "lucide-react";
+import { useRouter } from "next/navigation";
 import { useForm } from "react-hook-form";
 import { toast } from "sonner";
 import { z } from "zod";
@@ -18,6 +19,8 @@ import { FactoryResourceLink } from "@/features/factory/ui";
 import { TwinClassResourceLink } from "@/features/twin-class/ui";
 import { TwinTriggerResourceLink } from "@/features/twin-trigger/ui";
 import { PagedResponse } from "@/shared/api";
+import { PlatformArea } from "@/shared/config";
+import { isTruthy, toArray, toArrayOfString } from "@/shared/libs";
 import { GuidWithCopy } from "@/shared/ui";
 
 import { CrudDataTable, FiltersState } from "../../crud-data-table";
@@ -124,10 +127,24 @@ const colDefs: Record<
   },
 };
 
-export function FactoryTriggersTable() {
+export function FactoryTriggersTable({
+  twinTriggerId,
+}: {
+  twinTriggerId?: string;
+}) {
+  const router = useRouter();
   const { searchFactoryTrigger } = useFactoryTriggerSearch();
   const { buildFilterFields, mapFiltersToPayload } = useFactoryTriggerFilters({
-    enabledFilters: undefined,
+    enabledFilters: isTruthy(twinTriggerId)
+      ? [
+          "idList",
+          "twinFactoryIdList",
+          "inputTwinClassIdList",
+          "idList",
+          "active",
+          "async",
+        ]
+      : undefined,
   });
   const { createFactoryTrigger } = useFactoryTriggerCreate();
   async function fetchFactoryTriggers(
@@ -138,7 +155,12 @@ export function FactoryTriggersTable() {
     try {
       return await searchFactoryTrigger({
         pagination,
-        filters: _filters,
+        filters: {
+          ..._filters,
+          twinTriggerIdList: twinTriggerId
+            ? toArrayOfString(toArray(twinTriggerId), "id")
+            : _filters.twinTriggerIdList,
+        },
       });
     } catch (error) {
       toast.error("An error occured while fetching factory triggers:" + error);
@@ -151,6 +173,7 @@ export function FactoryTriggersTable() {
   const triggersForm = useForm<TriggersFormValues>({
     resolver: zodResolver(FACTORY_TRIGGER_SCHEMA),
     defaultValues: {
+      twinTriggerId: twinTriggerId || "",
       twinFactoryConditionInvert: false,
       active: false,
       async: false,
@@ -194,7 +217,7 @@ export function FactoryTriggersTable() {
         colDefs.twinFactoryConditionInvert,
         colDefs.active,
         colDefs.description,
-        colDefs.twinTrigger,
+        ...(twinTriggerId ? [] : [colDefs.twinTrigger]),
         colDefs.async,
       ]}
       fetcher={fetchFactoryTriggers}
@@ -206,11 +229,14 @@ export function FactoryTriggersTable() {
         colDefs.twinFactoryConditionInvert,
         colDefs.active,
         colDefs.description,
-        colDefs.twinTrigger,
+        ...(twinTriggerId ? [] : [colDefs.twinTrigger]),
         colDefs.async,
       ]}
       filters={{ filtersInfo: buildFilterFields() }}
       getRowId={(row) => row.id!}
+      onRowClick={(row) =>
+        router.push(`/${PlatformArea.core}/factory-triggers/${row.id}`)
+      }
       dialogForm={triggersForm}
       onCreateSubmit={handleOnCreateSubmit}
       renderFormFields={() => (

--- a/src/widgets/tables/factory-triggers/form-fields.tsx
+++ b/src/widgets/tables/factory-triggers/form-fields.tsx
@@ -1,4 +1,5 @@
-import { Control } from "react-hook-form";
+import { useRef } from "react";
+import { Control, useWatch } from "react-hook-form";
 import { z } from "zod";
 
 import {
@@ -20,6 +21,7 @@ import {
   useTwinClassSelectAdapterWithFilters,
 } from "@/entities/twin-class";
 import { useTwinTriggerSelectAdapter } from "@/entities/twin-trigger";
+import { isTruthy } from "@/shared/libs";
 
 type TriggersFormValues = z.infer<typeof FACTORY_TRIGGER_SCHEMA>;
 
@@ -36,6 +38,8 @@ export function TriggersFormFields({
     buildFilterFields: buildTwinClassFilters,
     mapFiltersToPayload: mapTwinClassFilters,
   } = useTwinClassFilters();
+  const twinTriggerWatch = useWatch({ control, name: "twinTriggerId" });
+  const disabled = useRef(isTruthy(twinTriggerWatch)).current;
 
   const twinClassInfo: AutoFormComplexComboboxValueInfo = {
     type: AutoFormValueType.complexCombobox,
@@ -97,6 +101,7 @@ export function TriggersFormFields({
         noItemsText="No data found"
         {...twinTriggerAdapter}
         required
+        disabled={disabled}
       />
       <SwitchFormField control={control} name="async" label="Async" />
     </>

--- a/src/widgets/tables/status-triggers/form-fields.tsx
+++ b/src/widgets/tables/status-triggers/form-fields.tsx
@@ -1,4 +1,5 @@
-import { Control } from "react-hook-form";
+import { useRef } from "react";
+import { Control, useWatch } from "react-hook-form";
 import { z } from "zod";
 
 import {
@@ -10,6 +11,7 @@ import {
 import { STATUS_TRIGGER_SCHEMA } from "@/entities/status-trigger";
 import { useTwinStatusSelectAdapter } from "@/entities/twin-status";
 import { useTwinTriggerSelectAdapter } from "@/entities/twin-trigger";
+import { isTruthy } from "@/shared/libs";
 
 type TriggersFormValues = z.infer<typeof STATUS_TRIGGER_SCHEMA>;
 
@@ -20,6 +22,8 @@ export function StatusTriggerFormFields({
 }) {
   const twinStatusAdapter = useTwinStatusSelectAdapter();
   const twinTriggerAdapter = useTwinTriggerSelectAdapter();
+  const twinTriggerWatch = useWatch({ control, name: "twinTriggerId" });
+  const disabled = useRef(isTruthy(twinTriggerWatch)).current;
 
   return (
     <>
@@ -53,6 +57,7 @@ export function StatusTriggerFormFields({
         noItemsText="No data found"
         {...twinTriggerAdapter}
         required
+        disabled={disabled}
       />
       <SwitchFormField control={control} name="async" label="Async" />
       <SwitchFormField control={control} name="active" label="Active" />

--- a/src/widgets/tables/status-triggers/status-triggers.tsx
+++ b/src/widgets/tables/status-triggers/status-triggers.tsx
@@ -18,6 +18,7 @@ import { TwinClassStatusResourceLink } from "@/features/twin-status/ui";
 import { TwinTriggerResourceLink } from "@/features/twin-trigger/ui";
 import { PagedResponse } from "@/shared/api";
 import { PlatformArea } from "@/shared/config";
+import { isTruthy, isUndefined, toArray, toArrayOfString } from "@/shared/libs";
 import { GuidWithCopy } from "@/shared/ui";
 
 import { CrudDataTable, FiltersState } from "../../crud-data-table";
@@ -93,27 +94,32 @@ const colDefs: Record<
 
 export function StatusTriggersTable({
   twinStatusId,
+  twinTriggerId,
 }: {
   twinStatusId?: string;
+  twinTriggerId?: string;
 }) {
   const router = useRouter();
   const { searchStatusTriggers } = useStatusTriggerSearch();
   const { createStatusTrigger } = useStatusTriggerCreate();
   const { buildFilterFields, mapFiltersToPayload } = useStatusTriggerFilters({
-    enabledFilters: twinStatusId
-      ? [
-          "idList",
-          "incomingElseOutgoing",
-          "twinTriggerIdList",
-          "active",
-          "async",
-        ]
-      : undefined,
+    enabledFilters:
+      isTruthy(twinStatusId) || isTruthy(twinTriggerId)
+        ? ([
+            "idList",
+            isUndefined(twinStatusId) && "twinStatusIdList",
+            "incomingElseOutgoing",
+            isUndefined(twinTriggerId) && "twinTriggerIdList",
+            "active",
+            "async",
+          ].filter(Boolean) as StatusTriggerFilterKeys[])
+        : undefined,
   });
 
   const statusTriggerForm = useForm<StatusTriggerFormValues>({
     resolver: zodResolver(STATUS_TRIGGER_SCHEMA),
     defaultValues: {
+      twinTriggerId: twinTriggerId || "",
       incomingElseOutgoing: false,
       order: 0,
       active: false,
@@ -134,7 +140,12 @@ export function StatusTriggersTable({
         pagination,
         filters: {
           ..._filters,
-          ...(twinStatusId ? { twinStatusIdList: [twinStatusId] } : {}),
+          twinStatusIdList: twinStatusId
+            ? toArrayOfString(toArray(twinStatusId), "id")
+            : _filters.twinStatusIdList,
+          twinTriggerIdList: twinTriggerId
+            ? toArrayOfString(toArray(twinTriggerId), "id")
+            : _filters.twinTriggerIdList,
         },
       });
     } catch (error) {
@@ -176,7 +187,7 @@ export function StatusTriggersTable({
         ...(twinStatusId ? [] : [colDefs.twinStatusId]),
         colDefs.incomingElseOutgoing,
         colDefs.order,
-        colDefs.twinTriggerId,
+        ...(twinTriggerId ? [] : [colDefs.twinTriggerId]),
         colDefs.async,
         colDefs.active,
       ]}
@@ -190,7 +201,7 @@ export function StatusTriggersTable({
         ...(twinStatusId ? [] : [colDefs.twinStatusId]),
         colDefs.incomingElseOutgoing,
         colDefs.order,
-        colDefs.twinTriggerId,
+        ...(twinTriggerId ? [] : [colDefs.twinTriggerId]),
         colDefs.async,
         colDefs.active,
       ]}

--- a/src/widgets/tables/transition-triggers/form-fields.tsx
+++ b/src/widgets/tables/transition-triggers/form-fields.tsx
@@ -1,5 +1,5 @@
 import { useRef } from "react";
-import { Control } from "react-hook-form";
+import { Control, useWatch } from "react-hook-form";
 import { z } from "zod";
 
 import {
@@ -23,6 +23,8 @@ export function TriggersFormFields({
   transitionId?: string;
 }) {
   const twinTriggerAdapter = useTwinTriggerSelectAdapter();
+  const twinTriggerWatch = useWatch({ control, name: "twinTriggerId" });
+  const disabledTwinTrigger = useRef(isTruthy(twinTriggerWatch)).current;
   const transitionAdapter = useTransitionSelectAdapter();
   const disabled = useRef(isTruthy(transitionId)).current;
 
@@ -55,6 +57,7 @@ export function TriggersFormFields({
         noItemsText="No data found"
         {...twinTriggerAdapter}
         required
+        disabled={disabledTwinTrigger}
       />
       <SwitchFormField control={control} name="async" label="Async" />
     </>

--- a/src/widgets/tables/transition-triggers/transition-triggers.tsx
+++ b/src/widgets/tables/transition-triggers/transition-triggers.tsx
@@ -9,6 +9,7 @@ import { z } from "zod";
 
 import {
   TRANSITION_TRIGGER_SCHEMA,
+  TransitionTriggerFilterKeys,
   TransitionTrigger_DETAILED,
   useTransitionTriggerCreate,
   useTransitionTriggerSearch,
@@ -19,7 +20,13 @@ import { TwinFlowTransitionResourceLink } from "@/features/twin-flow-transition/
 import { TwinTriggerResourceLink } from "@/features/twin-trigger/ui";
 import { PagedResponse } from "@/shared/api/types";
 import { PlatformArea } from "@/shared/config";
-import { isFalsy } from "@/shared/libs";
+import {
+  isFalsy,
+  isTruthy,
+  isUndefined,
+  toArray,
+  toArrayOfString,
+} from "@/shared/libs";
 import { GuidWithCopy } from "@/shared/ui/guid";
 
 import {
@@ -93,7 +100,11 @@ const colDefs: Record<
   },
 };
 
-export function TransitionTriggersTable() {
+export function TransitionTriggersTable({
+  twinTriggerId,
+}: {
+  twinTriggerId?: string;
+}) {
   const router = useRouter();
   const { transitionId } = useContext(TwinFlowTransitionContext);
   const tableRef = useRef<DataTableHandle>(null);
@@ -101,15 +112,17 @@ export function TransitionTriggersTable() {
   const { createTransitionTrigger } = useTransitionTriggerCreate();
   const { buildFilterFields, mapFiltersToPayload } =
     useTransitionTriggerFilters({
-      enabledFilters: transitionId
-        ? ["idList", "twinTriggerIdList", "active", "async"]
-        : [
-            "idList",
-            "twinflowTransitionIdList",
-            "twinTriggerIdList",
-            "active",
-            "async",
-          ],
+      enabledFilters:
+        isTruthy(transitionId) || isTruthy(twinTriggerId)
+          ? ([
+              "idList",
+              isUndefined(transitionId) && "twinflowTransitionIdList",
+              "incomingElseOutgoing",
+              isUndefined(twinTriggerId) && "twinTriggerIdList",
+              "active",
+              "async",
+            ].filter(Boolean) as TransitionTriggerFilterKeys[])
+          : undefined,
     });
 
   async function fetchData(
@@ -123,7 +136,12 @@ export function TransitionTriggersTable() {
         pagination,
         filters: {
           ..._filters,
-          ...(transitionId ? { twinflowTransitionIdList: [transitionId] } : {}),
+          twinflowTransitionIdList: transitionId
+            ? toArrayOfString(toArray(transitionId), "id")
+            : _filters.twinflowTransitionIdList,
+          twinTriggerIdList: twinTriggerId
+            ? toArrayOfString(toArray(twinTriggerId), "id")
+            : _filters.twinTriggerIdList,
         },
       });
     } catch (error) {
@@ -139,7 +157,8 @@ export function TransitionTriggersTable() {
   const triggersForm = useForm<TriggersFormValues>({
     resolver: zodResolver(TRANSITION_TRIGGER_SCHEMA),
     defaultValues: {
-      ...(transitionId ? { twinflowTransitionId: transitionId } : {}),
+      twinflowTransitionId: transitionId || "",
+      twinTriggerId: twinTriggerId || "",
       order: 0,
       active: true,
       async: false,
@@ -180,7 +199,7 @@ export function TransitionTriggersTable() {
         colDefs.id,
         ...(isFalsy(transitionId) ? [colDefs.twinflowTransitionId] : []),
         colDefs.order,
-        colDefs.twinTriggerId,
+        ...(twinTriggerId ? [] : [colDefs.twinTriggerId]),
         colDefs.async,
         colDefs.active,
       ]}
@@ -193,7 +212,7 @@ export function TransitionTriggersTable() {
         colDefs.id,
         ...(isFalsy(transitionId) ? [colDefs.twinflowTransitionId] : []),
         colDefs.order,
-        colDefs.twinTriggerId,
+        ...(twinTriggerId ? [] : [colDefs.twinTriggerId]),
         colDefs.async,
         colDefs.active,
       ]}


### PR DESCRIPTION
## Summary

_Implement [page] twin trigger [tab] usages_

## Jira Ticket

- Related ticket: [TWINFACES-946](https://alcosi.atlassian.net/browse/TWINFACES-946)
- Related ticket: [TWINFACES-878](https://alcosi.atlassian.net/browse/TWINFACES-878)
- 
## Description

- Implement [page] twin trigger [tab] usages

## Testing

1. **Setup**
   - https://dev-twins.onshelves.me/
2. **Steps**
   1. Go to `twin trigger`
   2. Click `row -> usages`
   3. Observe that `tables` happens

[TWINFACES-946]: https://alcosi.atlassian.net/browse/TWINFACES-946?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[TWINFACES-878]: https://alcosi.atlassian.net/browse/TWINFACES-878?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ