### PR TITLE
[TWINFACES-955] Implement [page] status [tab] transitions

### DIFF
--- a/src/entities/twin-flow-transition/api/hooks/use-create-transition.ts
+++ b/src/entities/twin-flow-transition/api/hooks/use-create-transition.ts
@@ -7,12 +7,7 @@ export const useCreateTwinFlowTransition = () => {
   const api = useContext(PrivateApiContext);
 
   const createTwinFlowTransition = useCallback(
-    async ({
-      body,
-    }: {
-      twinFlowId: string;
-      body: TwinFlowTransitionCreateRq;
-    }) => {
+    async ({ body }: { body: TwinFlowTransitionCreateRq }) => {
       try {
         const result = await api.twinFlowTransition.create({
           body,

--- a/src/screens/status/status.tsx
+++ b/src/screens/status/status.tsx
@@ -1,6 +1,10 @@
 import { Tab, TabsLayout } from "@/widgets/layout";
 
-import { TwinStatusGeneral, TwinStatusTriggers } from "./views";
+import {
+  TwinStatusGeneral,
+  TwinStatusTransitions,
+  TwinStatusTriggers,
+} from "./views";
 
 export function StatusScreen() {
   const tabs: Tab[] = [
@@ -13,6 +17,11 @@ export function StatusScreen() {
       key: "triggers",
       label: "Triggers",
       content: <TwinStatusTriggers />,
+    },
+    {
+      key: "transitions",
+      label: "Transitions",
+      content: <TwinStatusTransitions />,
     },
   ];
 

--- a/src/screens/status/views/index.ts
+++ b/src/screens/status/views/index.ts
@@ -1,2 +1,3 @@
 export * from "./status-general";
+export * from "./status-transitions";
 export * from "./status-triggers";

--- a/src/screens/status/views/status-transitions.tsx
+++ b/src/screens/status/views/status-transitions.tsx
@@ -1,0 +1,18 @@
+"use client";
+
+import { useContext } from "react";
+
+import { TwinStatusContext } from "@/features/twin-status";
+import { TwinFlowTransitionsTable } from "@/widgets/tables";
+
+export function TwinStatusTransitions() {
+  const { twinStatusId } = useContext(TwinStatusContext);
+
+  return (
+    <>
+      <TwinFlowTransitionsTable twinStatusId={twinStatusId} title="Incoming" />
+
+      <TwinFlowTransitionsTable twinStatusId={twinStatusId} title="Outgoing" />
+    </>
+  );
+}

--- a/src/screens/twin-flow-transitions/twin-flow-transitions.tsx
+++ b/src/screens/twin-flow-transitions/twin-flow-transitions.tsx
@@ -3,5 +3,5 @@
 import { TwinFlowTransitionsTable } from "@/widgets/tables";
 
 export function TransitionsScreen() {
-  return <TwinFlowTransitionsTable />;
+  return <TwinFlowTransitionsTable title="Transitions" />;
 }

--- a/src/screens/twin-flow/twin-flow.tsx
+++ b/src/screens/twin-flow/twin-flow.tsx
@@ -21,7 +21,9 @@ export function TwinFlowScreen() {
     {
       key: "transitions",
       label: "Transitions",
-      content: <TwinFlowTransitionsTable twinflow={twinFlow} />,
+      content: (
+        <TwinFlowTransitionsTable twinflow={twinFlow} title="Transitions" />
+      ),
     },
     {
       key: "flow",

--- a/src/widgets/tables/twin-flow-transitions/form-fields.tsx
+++ b/src/widgets/tables/twin-flow-transitions/form-fields.tsx
@@ -15,13 +15,18 @@ import { useTwinStatusSelectAdapter } from "@/entities/twin-status";
 import {
   isFalsy,
   isPopulatedArray,
+  isTruthy,
   reduceToObject,
   toArray,
 } from "@/shared/libs";
 
 export function TwinFlowTransitionFormFields({
+  type,
+  twinStatusId,
   control,
 }: {
+  twinStatusId?: string;
+  type?: string;
   control: Control<TwinFlowTransitionFormValues>;
 }) {
   const twinFlowWatch = useWatch({ control, name: "twinflow" });
@@ -29,6 +34,9 @@ export function TwinFlowTransitionFormFields({
 
   const twinClassId = twinFlowWatch[0]?.twinClassId;
   const disabledStatus = isFalsy(twinClassId);
+
+  const disabledSrcStatus = isTruthy(twinStatusId) && type === "Incoming";
+  const disabledDstStatus = isTruthy(twinStatusId) && type === "Outgoing";
 
   const twinFlowAdapter = useTwinFlowSelectAdapter();
   const permissionAdapter = usePermissionSelectAdapter();
@@ -89,7 +97,7 @@ export function TwinFlowTransitionFormFields({
         selectPlaceholder="Select status"
         searchPlaceholder="Search status..."
         noItemsText="No status found"
-        disabled={disabledStatus}
+        disabled={disabledStatus || disabledSrcStatus}
         {...twinStatusAdapter}
         getItems={async (search: string) => {
           return twinStatusAdapter.getItems(search, {
@@ -109,7 +117,7 @@ export function TwinFlowTransitionFormFields({
         searchPlaceholder="Search status..."
         noItemsText="No status found"
         required={true}
-        disabled={disabledStatus}
+        disabled={disabledStatus || disabledDstStatus}
         {...twinStatusAdapter}
         getItems={async (search: string) => {
           return twinStatusAdapter.getItems(search, {

--- a/src/widgets/tables/twin-flow-transitions/twin-flow-transitions.tsx
+++ b/src/widgets/tables/twin-flow-transitions/twin-flow-transitions.tsx
@@ -11,6 +11,7 @@ import {
   TWIN_FLOW_TRANSITION_SCHEMA,
   TwinFlowTransition,
   TwinFlowTransitionCreateRq,
+  TwinFlowTransitionFilterKeys,
   TwinFlowTransitionFormValues,
   TwinFlowTransition_DETAILED,
   useCreateTwinFlowTransition,
@@ -174,26 +175,31 @@ const colDefs: Record<
 
 export function TwinFlowTransitionsTable({
   twinflow,
+  title,
+  twinStatusId,
 }: {
+  twinStatusId?: string;
+  title?: string;
   twinflow?: TwinFlow;
 }) {
   const router = useRouter();
   const { buildFilterFields, mapFiltersToPayload } =
     useTwinFlowTransitionFilters({
       twinClassId: twinflow?.twinClassId,
-      enabledFilters: isTruthy(twinflow?.id)
-        ? [
-            "idList",
-            "aliasLikeList",
-            "nameLikeList",
-            "twinflowTransitionTypeList",
-            "descriptionLikeList",
-            "srcStatusIdList",
-            "dstStatusIdList",
-            "permissionIdList",
-            "inbuiltTwinFactoryIdList",
-          ]
-        : undefined,
+      enabledFilters:
+        isTruthy(twinflow?.id) || isTruthy(twinStatusId)
+          ? ([
+              "idList",
+              "aliasLikeList",
+              "nameLikeList",
+              "twinflowTransitionTypeList",
+              "descriptionLikeList",
+              title !== "Incoming" && "srcStatusIdList",
+              title !== "Outgoing" && "dstStatusIdList",
+              "permissionIdList",
+              "inbuiltTwinFactoryIdList",
+            ].filter(Boolean) as TwinFlowTransitionFilterKeys[])
+          : undefined,
     });
   const { searchTwinFlowTransitions } = useTwinFlowTransitionSearchV1();
   const { createTwinFlowTransition } = useCreateTwinFlowTransition();
@@ -204,8 +210,8 @@ export function TwinFlowTransitionsTable({
       twinflow: twinflow ? [twinflow] : [],
       name: "",
       description: "",
-      srcTwinStatusId: undefined,
-      dstTwinStatusId: "",
+      srcTwinStatusId: twinStatusId && title === "Incoming" ? twinStatusId : "",
+      dstTwinStatusId: twinStatusId && title === "Outgoing" ? twinStatusId : "",
       permissionId: undefined,
     },
   });
@@ -225,6 +231,14 @@ export function TwinFlowTransitionsTable({
             twinflowIdList: twinflow?.id
               ? toArrayOfString(toArray(twinflow?.id), "id")
               : _filters.twinflowIdList,
+            srcStatusIdList:
+              twinStatusId && title === "Incoming"
+                ? toArrayOfString(toArray(twinStatusId), "id")
+                : _filters.srcStatusIdList,
+            dstStatusIdList:
+              twinStatusId && title === "Outgoing"
+                ? toArrayOfString(toArray(twinStatusId), "id")
+                : _filters.dstStatusIdList,
           },
         });
 
@@ -261,12 +275,12 @@ export function TwinFlowTransitionsTable({
           dstStatusId: formValues.dstTwinStatusId,
           permissionId: formValues.permissionId,
           twinflowTransitionTypeId: formValues.twinflowTransitionTypeId,
+          twinflowId: formValues.twinflow[0]?.id!,
         },
       ],
     };
 
     await createTwinFlowTransition({
-      twinFlowId: formValues.twinflow[0]?.id!,
       body,
     });
     toast.success("Transition created successfully!");
@@ -274,7 +288,7 @@ export function TwinFlowTransitionsTable({
 
   return (
     <CrudDataTable
-      title="Transitions"
+      title={title}
       className="mx-auto mb-10 flex-col p-8 lg:flex lg:justify-center"
       columns={[
         colDefs.id,
@@ -282,8 +296,8 @@ export function TwinFlowTransitionsTable({
         colDefs.name,
         colDefs.type,
         colDefs.alias,
-        colDefs.srcTwinStatusId,
-        colDefs.dstTwinStatusId,
+        ...(title !== "Incoming" ? [colDefs.srcTwinStatusId] : []),
+        ...(title !== "Outgoing" ? [colDefs.dstTwinStatusId] : []),
         colDefs.permissionId,
         colDefs.inbuiltTwinFactoryId,
         colDefs.description,
@@ -314,7 +328,11 @@ export function TwinFlowTransitionsTable({
       dialogForm={form}
       onCreateSubmit={handleCreate}
       renderFormFields={() => (
-        <TwinFlowTransitionFormFields control={form.control} />
+        <TwinFlowTransitionFormFields
+          type={title}
+          twinStatusId={twinStatusId}
+          control={form.control}
+        />
       )}
     />
   );


### PR DESCRIPTION
## Summary

_Implement [page] status [tab] transitions_

## Jira Ticket

- Related ticket: [TWINFACES-955](https://alcosi.atlassian.net/browse/TWINFACES-955)
- Related ticket: [TWINFACES-951](https://alcosi.atlassian.net/browse/TWINFACES-951)
- 
## Description

- Implement [page] status [tab] transitions

## Testing

1. **Setup**
   - https://dev-twins.onshelves.me/
2. **Steps**
   1. Go to ` Statuses`
   2. Click `row -> transitions` (ex. 7d125890-d02b-4161-92bc-38e07f948084 statusId)
   3. Observe that `tables Incoming & Outgoing` happens

[TWINFACES-955]: https://alcosi.atlassian.net/browse/TWINFACES-955?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[TWINFACES-951]: https://alcosi.atlassian.net/browse/TWINFACES-951?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ